### PR TITLE
Proper wrapping of PyTorch using __torch_function__

### DIFF
--- a/storch/__init__.py
+++ b/storch/__init__.py
@@ -15,9 +15,3 @@ from .util import print_graph
 from .storch import *
 import storch.typing
 import storch.nn
-from .excluded_init import (
-    _excluded_init,
-    _exception_init,
-    _unwrap_only_init,
-    _excluded_function,
-)

--- a/storch/__init__.py
+++ b/storch/__init__.py
@@ -1,5 +1,4 @@
 _debug = False
-from typing import Callable
 
 from .wrappers import (
     deterministic,
@@ -9,50 +8,16 @@ from .wrappers import (
     _unpack_wrapper,
     ignore_wrapping,
 )
-from .tensor import Tensor, CostTensor, StochasticTensor, Plate
+from .tensor import Tensor, CostTensor, StochasticTensor, Plate, is_tensor
 from .method import *
 from .inference import backward, add_cost, reset, denote_independent, gather_samples
 from .util import print_graph
 from .storch import *
 import storch.typing
 import storch.nn
-from inspect import isclass
 from .excluded_init import (
     _excluded_init,
     _exception_init,
     _unwrap_only_init,
     _excluded_function,
 )
-
-
-# Wrap all (common) normal PyTorch functions. This is required because they call
-# C code. The returned tensors from the C code can only automatically be wrapped
-# by wrapping the functions that call the C code.
-# Ignore the first 35 as they are not related to tensors
-let_through = False
-for m, v in torch.__dict__.items():
-    if m == "_adaptive_avg_pool2d":
-        let_through = True
-    if not let_through or not isinstance(v, Callable):
-        continue
-    if m in _exception_init:
-        torch.__dict__[m] = _exception_wrapper(v)
-    elif m in _unwrap_only_init:
-        torch.__dict__[m] = _unpack_wrapper(v)
-    elif (
-        not isclass(v)
-        and not str.startswith(m, "_cufft_")
-        and not str.startswith(m, "rand")
-        and m not in _excluded_init
-    ):
-        torch.__dict__[m] = deterministic(v)
-    else:
-        continue
-    # torch.__dict__[m].__module__ = "torch"
-
-let_through = False
-for m, v in torch.nn.functional.__dict__.items():
-    if m == "conv1d":
-        let_through = True
-    if let_through and isinstance(v, Callable) and m not in _excluded_function:
-        torch.nn.functional.__dict__[m] = deterministic(v)

--- a/storch/excluded_init.py
+++ b/storch/excluded_init.py
@@ -118,4 +118,9 @@ _unwrap_only_tensor = {
 }
 
 _to_test_tensor = {"_make_subclass"}
+
+exception_methods = _exception_init.union(_exception_tensor)
+excluded_methods = _excluded_tensor.union(_excluded_function).union(_excluded_init)
+unwrap_only_methods = _unwrap_only_tensor.union(_unwrap_only_init)
+
 # print(_excluded_init)

--- a/storch/method/sampling.py
+++ b/storch/method/sampling.py
@@ -264,15 +264,11 @@ class SampleWithoutReplacementMethod(Method):
                     break
 
         # plates x k x events
-        sampled_support_indices = storch.Tensor(
-            support.new_zeros(
-                size=support.shape[:support_k_index]  # distr_plates
-                + (self.k,)
-                + support.shape[support_k_index + 1 : -len(element_shape)],  # events
-                dtype=torch.long,
-            ),
-            [],
-            all_plates,
+        sampled_support_indices = support.new_zeros(
+            size=support.shape[:support_k_index]  # distr_plates
+            + (self.k,)
+            + support.shape[support_k_index + 1 : -len(element_shape)],  # events
+            dtype=torch.long,
         )
 
         amt_samples = 0
@@ -282,13 +278,10 @@ class SampleWithoutReplacementMethod(Method):
             # Note that self.joint_log_probs.shape[-1] is amt_samples, not k. It's possible that amt_samples < k!
             amt_samples = self.joint_log_probs.shape[-1]
             # plates x k
-            self.parent_indexing = storch.Tensor(
-                support.new_zeros(
-                    size=support.shape[:amt_plates] + (self.k,), dtype=torch.long
-                ),
-                [],
-                all_plates,
+            self.parent_indexing = support.new_zeros(
+                size=support.shape[:amt_plates] + (self.k,), dtype=torch.long
             )
+
             # probably can go wrong if plates are missing.
             self.parent_indexing[..., :amt_samples] = left_expand_as(
                 torch.arange(amt_samples), self.parent_indexing
@@ -356,6 +349,7 @@ class SampleWithoutReplacementMethod(Method):
                 indexing = (
                     (slice(None),) * amt_plates + (slice(0, amt_samples),) + indices
                 )
+                print(sampled_support_indices[indexing])
                 sampled_support_indices[indexing] = arg_top
             else:
                 # plates x (k * |D_yv|) (k == prev_amt_samples, in this case)

--- a/storch/method/sampling.py
+++ b/storch/method/sampling.py
@@ -378,7 +378,7 @@ class SampleWithoutReplacementMethod(Method):
 
                 # Keep track of what parents were sampled for the arg top
                 # plates x amt_samples
-                chosen_parents = arg_top / size_domain
+                chosen_parents = arg_top // size_domain
                 sampled_support_indices = sampled_support_indices.gather(
                     dim=support_k_index,
                     index=right_expand_as(chosen_parents, sampled_support_indices),

--- a/storch/tensor.py
+++ b/storch/tensor.py
@@ -215,11 +215,11 @@ class Tensor:
     def __eq__(self, other):
         return self.__eq__(other)
 
-    @storch.deterministic
+    @storch.deterministic(l_broadcast=False)
     def __getitem__(self, index):
         return self.__getitem__(index)
 
-    @storch.deterministic
+    @storch.deterministic(l_broadcast=False)
     def __setitem__(self, index, value):
         return self.__setitem__(index, value)
 
@@ -483,6 +483,10 @@ class Tensor:
     @storch.deterministic
     def __sub__(self, other):
         return self.__sub__(other)
+
+    @storch.deterministic
+    def __rsub__(self, other):
+        return self.__rsub__(other)
 
     @storch.deterministic
     def __mul__(self, other):

--- a/storch/tensor.py
+++ b/storch/tensor.py
@@ -172,7 +172,6 @@ class Tensor:
 
         TODO: This should probably filter the methods
         """
-        print(func)
         if kwargs is None:
             kwargs = {}
         return storch.wrappers._handle_deterministic(func, args, kwargs)
@@ -389,9 +388,8 @@ class Tensor:
     def __len__(self):
         return self._tensor.__len__()
 
-    # TODO: Is this safe?
     def __index__(self):
-        return self._tensor.__index__()
+        raise IllegalStorchExposeError("Cannot use storch tensors as index.")
 
     # TODO: shouldn't this have @deterministic?
     def eq(self, other):
@@ -467,6 +465,7 @@ class Tensor:
         )
 
     def __iter__(self):
+        # TODO: This recognizes storch.Tensor as Iterable, even though it's not implemented.
         raise NotImplementedError("Cannot currently iterate over storch Tensors.")
 
     def detach_(self) -> Tensor:

--- a/storch/tensor.py
+++ b/storch/tensor.py
@@ -3,11 +3,10 @@ import torch
 import storch
 from torch.distributions import Distribution
 from collections import deque
-from typing import Union, List, Tuple, Dict, Iterable, Any, Callable
+from typing import List, Iterable, Any, Callable
 import builtins
 from itertools import product
 from typing import Optional
-from torch import Size
 from storch.exceptions import IllegalStorchExposeError
 from storch.excluded_init import (
     _exception_tensor,
@@ -16,11 +15,6 @@ from storch.excluded_init import (
 )
 
 # from storch.typing import BatchTensor
-
-_int = builtins.int
-_size = Union[Size, List[_int], Tuple[_int, ...]]
-
-_torch_dict = None
 
 
 class Plate:
@@ -102,7 +96,7 @@ class Plate:
         return tensor
 
 
-class Tensor(torch.Tensor):
+class Tensor:
     def __init__(
         self,
         tensor: torch.Tensor,
@@ -171,15 +165,29 @@ class Tensor(torch.Tensor):
         self.event_dims = len(self.event_shape)
         self.plates = plates
 
-    @staticmethod
-    def __new__(cls, *args, **kwargs):
-        # Pass the input tensor to register this tensor in C. This will initialize an empty (0s?) tensor in the backend.
-        # TODO: Does that mean it will require double the memory?
-        # return super(Tensor, cls).__new__(cls, device=tensor.device)
-        return super(Tensor, cls).__new__(cls)
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        """
+        Called whenever a torch.* or torch.nn.functional.* method is being called on a storch.Tensor. This wraps
+        that method in the deterministic wrapper to properly handle all input arguments and outputs.
 
-    def __hash__(self):
-        return object.__hash__(self)
+        TODO: This should probably filter the methods
+        """
+        print(func)
+        if kwargs is None:
+            kwargs = {}
+        return storch.wrappers._handle_deterministic(func, args, kwargs)
+
+    def __getattr__(self, item):
+        """
+        Called whenever an attribute is called on a storch.Tensor object that is not directly implemented by storch.Tensor.
+        It defers it to the underlying torch.Tensor. If it is a callable (ie, torch.Tensor implements a function
+        with the name item), it will wrap this callable with a deterministic wrapper.
+
+        TODO: This should probably filter the methods
+        """
+        attr = getattr(torch.Tensor, item)
+        if isinstance(attr, Callable):
+            return storch.wrappers._self_deterministic(attr, self)
 
     @property
     def name(self):
@@ -200,9 +208,20 @@ class Tensor(torch.Tensor):
     def __repr__(self):
         return self._tensor.__repr__()
 
+    def __hash__(self):
+        return object.__hash__(self)
+
     @storch.deterministic
     def __eq__(self, other):
         return self.__eq__(other)
+
+    @storch.deterministic
+    def __getitem__(self, index):
+        return self.__getitem__(index)
+
+    @storch.deterministic
+    def __setitem__(self, index, value):
+        return self.__setitem__(index, value)
 
     def _walk(
         self,
@@ -285,6 +304,9 @@ class Tensor(torch.Tensor):
     @property
     def plate_shape(self) -> torch.Size:
         return self._tensor.shape[: self.plate_dims]
+
+    def size(self) -> torch.Size:
+        return self._tensor.size()
 
     @property
     def shape(self) -> torch.Size:
@@ -450,80 +472,107 @@ class Tensor(torch.Tensor):
     def detach_(self) -> Tensor:
         raise NotImplementedError("In place detach is not allowed on storch tensors.")
 
+    @storch.deterministic
+    def __add__(self, other):
+        return self.__add__(other)
+
+    @storch.deterministic
+    def __radd__(self, other):
+        return self.__radd__(other)
+
+    @storch.deterministic
+    def __sub__(self, other):
+        return self.__sub__(other)
+
+    @storch.deterministic
+    def __mul__(self, other):
+        return self.__mul__(other)
+
+    @storch.deterministic
+    def __rmul__(self, other):
+        return self.__rmul__(other)
+
+    @storch.deterministic
+    def __matmul__(self, other):
+        return self.__matmul__(other)
+
+    @storch.deterministic
+    def __pow__(self, other):
+        return self.__pow__(other)
+
+    @storch.deterministic
+    def __div__(self, other):
+        return self.__div__(other)
+
+    @storch.deterministic
+    def __mod__(self, other):
+        return self.__mod__(other)
+
+    @storch.deterministic
+    def __truediv__(self, other):
+        return self.__truediv__(other)
+
+    @storch.deterministic
+    def __floordiv__(self, other):
+        return self.__floordiv__(other)
+
+    @storch.deterministic
+    def __rfloordiv__(self, other):
+        return self.__rfloordiv__(other)
+
+    @storch.deterministic
+    def __abs__(self):
+        return self.__abs__()
+
+    @storch.deterministic
+    def __and__(self, other):
+        return self.__and__(other)
+
+    @storch.deterministic
+    def __ge__(self, other):
+        return self.__ge__(other)
+
+    @storch.deterministic
+    def __gt__(self, other):
+        return self.__gt__(other)
+
+    @storch.deterministic
+    def __invert__(self):
+        return self.__invert__()
+
+    @storch.deterministic
+    def __le__(self, other):
+        return self.__le__(other)
+
+    @storch.deterministic
+    def __lshift__(self, other):
+        return self.__lshift__(other)
+
+    @storch.deterministic
+    def __lt__(self, other):
+        return self.__lt__(other)
+
+    @storch.deterministic
+    def ne(self, other):
+        return self.ne(other)
+
+    @storch.deterministic
+    def __neg__(self):
+        return self.__neg__()
+
+    @storch.deterministic
+    def __or__(self, other):
+        return self.__or__(other)
+
+    @storch.deterministic
+    def __rshift__(self, other):
+        return self.__rshift__(other)
+
+    @storch.deterministic
+    def __xor__(self, other):
+        return self.__xor__(other)
+
     # endregion
-
-
-for m in dir(torch.Tensor):
-    v = getattr(torch.Tensor, m)
-    if (
-        isinstance(v, Callable)
-        and m not in Tensor.__dict__
-        # and m not in object.__dict__
-    ):
-        if m in _exception_tensor:
-            if storch._debug:
-                print("exception:" + m)
-            setattr(torch.Tensor, m, storch._exception_wrapper(v))
-        elif m in _unwrap_only_tensor:
-            if storch._debug:
-                print("unwrap only:" + m)
-            setattr(torch.Tensor, m, storch._unpack_wrapper(v))
-        elif m not in _excluded_tensor:
-            if storch._debug:
-                print("in:" + m)
-            setattr(torch.Tensor, m, storch.deterministic(v))
-        elif storch._debug:
-            print("excluded:" + m)
-    elif storch._debug:
-        print("out:" + m)
-
-# Yes. This code is extremely weird. For some reason, when monkey patching torch.Tensor.__getitem__ and
-# torch.Tensor.__setitem__, bizarre indexing bugs will happen that wouldn't happen when not monkey patching them.
-# Unsqueezing the masking tensor sometimes seems to help...
-# To do this, I also had to reset the torch.Tensor method to its original state. This bug should be fixed sometimes,
-# as this is extremely messy code.
-original_get = torch.Tensor.__getitem__
-
-_getitem_level = 0
-
-
-class WrapGet:
-    def __init__(self, original_fn):
-        self.original_fn = storch.deterministic(original_fn)
-
-    def __get__(self, *args):
-        # The __getitem__ method is a slotwrapper object that first calls the __get__ to create a method_wrapper.
-        # This class is a hacky wrapper around those wrappers (pff) to allow compatibility with storch.
-        self.is_arg_none = args[0] is None
-        self.arg0 = args[0]
-        return lambda *args: self.__call__(*args)
-
-    def __call__(self, *args):
-        # For some reason, when monkey patching __getitem__ and __setitem__, incorrect recursive calls happen that
-        # cause wrong outputs. This wrapper seems to block some of these recursive calls, but this requires more
-        # investigation as to why it works.
-        global _getitem_level
-        _getitem_level += 1
-        # TODO: This seems to fix incorrect outcomes from wrapping. I still don't know why or how, though.
-        try:
-            if _getitem_level == 1 and not self.is_arg_none:
-                out = self.original_fn(self.arg0, *args)
-            else:
-                out = self.original_fn(*args)
-        except TypeError as e:
-            if storch._debug:
-                print(_getitem_level, e)
-            if _getitem_level == 1:
-                out = self.original_fn(self.arg0, *args)
-        finally:
-            _getitem_level -= 1
-
-        return out
-
-
-torch.Tensor.__getitem__ = WrapGet(torch.Tensor.__getitem__)
-
-torch.Tensor.__setitem__ = WrapGet(torch.Tensor.__setitem__)
 
 
 class CostTensor(Tensor):
@@ -605,4 +654,5 @@ class StochasticTensor(Tensor):
         return self.param_grads
 
 
+is_tensor = lambda a: isinstance(a, torch.Tensor) or isinstance(a, Tensor)
 from storch.util import has_backwards_path

--- a/storch/util.py
+++ b/storch/util.py
@@ -5,12 +5,7 @@ from pyro.distributions import (
     RelaxedBernoulliStraightThrough,
 )
 
-from storch.tensor import (
-    Tensor,
-    CostTensor,
-    StochasticTensor,
-    Plate,
-)
+from storch.tensor import Tensor, CostTensor, StochasticTensor, Plate, is_tensor
 from torch.distributions import (
     Distribution,
     RelaxedOneHotCategorical,
@@ -66,9 +61,7 @@ def get_distr_parameters(
     for k in d.arg_constraints:
         try:
             p = getattr(d, k)
-            if isinstance(p, torch.Tensor) and (
-                not filter_requires_grad or p.requires_grad
-            ):
+            if is_tensor(p) and (not filter_requires_grad or p.requires_grad):
                 params[k] = p
         except AttributeError:
             from storch import _debug

--- a/storch/wrappers.py
+++ b/storch/wrappers.py
@@ -22,7 +22,7 @@ _ignore_wrap = False
 def is_iterable(a: Any):
     return (
         isinstance(a, Iterable)
-        and not isinstance(a, torch.Tensor)
+        and not storch.is_tensor(a)
         and not isinstance(a, str)
         and not isinstance(a, torch.Storage)
     )

--- a/test/collect_env.py
+++ b/test/collect_env.py
@@ -1,0 +1,402 @@
+# This script outputs relevant system environment info
+# Run it with `python collect_env.py`.
+from __future__ import absolute_import, division, print_function, unicode_literals
+import locale
+import re
+import subprocess
+import sys
+import os
+from collections import namedtuple
+
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except (ImportError, NameError, AttributeError):
+    TORCH_AVAILABLE = False
+
+# System Environment Information
+SystemEnv = namedtuple(
+    "SystemEnv",
+    [
+        "torch_version",
+        "is_debug_build",
+        "cuda_compiled_version",
+        "gcc_version",
+        "cmake_version",
+        "os",
+        "python_version",
+        "is_cuda_available",
+        "cuda_runtime_version",
+        "nvidia_driver_version",
+        "nvidia_gpu_models",
+        "cudnn_version",
+        "pip_version",  # 'pip' or 'pip3'
+        "pip_packages",
+        "conda_packages",
+    ],
+)
+
+
+def run(command):
+    """Returns (return-code, stdout, stderr)"""
+    p = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    output, err = p.communicate()
+    rc = p.returncode
+    enc = locale.getpreferredencoding()
+    output = output.decode(enc)
+    err = err.decode(enc)
+    return rc, output.strip(), err.strip()
+
+
+def run_and_read_all(run_lambda, command):
+    """Runs command using run_lambda; reads and returns entire output if rc is 0"""
+    rc, out, _ = run_lambda(command)
+    if rc != 0:
+        return None
+    return out
+
+
+def run_and_parse_first_match(run_lambda, command, regex):
+    """Runs command using run_lambda, returns the first regex match if it exists"""
+    rc, out, _ = run_lambda(command)
+    if rc != 0:
+        return None
+    match = re.search(regex, out)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def get_conda_packages(run_lambda):
+    if get_platform() == "win32":
+        grep_cmd = r'findstr /R "torch numpy cudatoolkit soumith mkl magma"'
+    else:
+        grep_cmd = r'grep "torch\|numpy\|cudatoolkit\|soumith\|mkl\|magma"'
+    conda = os.environ.get("CONDA_EXE", "conda")
+    out = run_and_read_all(run_lambda, conda + " list | " + grep_cmd)
+    if out is None:
+        return out
+    # Comment starting at beginning of line
+    comment_regex = re.compile(r"^#.*\n")
+    return re.sub(comment_regex, "", out)
+
+
+def get_gcc_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, "gcc --version", r"gcc (.*)")
+
+
+def get_cmake_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, "cmake --version", r"cmake (.*)")
+
+
+def get_nvidia_driver_version(run_lambda):
+    if get_platform() == "darwin":
+        cmd = "kextstat | grep -i cuda"
+        return run_and_parse_first_match(
+            run_lambda, cmd, r"com[.]nvidia[.]CUDA [(](.*?)[)]"
+        )
+    smi = get_nvidia_smi()
+    return run_and_parse_first_match(run_lambda, smi, r"Driver Version: (.*?) ")
+
+
+def get_gpu_info(run_lambda):
+    if get_platform() == "darwin":
+        if TORCH_AVAILABLE and torch.cuda.is_available():
+            return torch.cuda.get_device_name(None)
+        return None
+    smi = get_nvidia_smi()
+    uuid_regex = re.compile(r" \(UUID: .+?\)")
+    rc, out, _ = run_lambda(smi + " -L")
+    if rc != 0:
+        return None
+    # Anonymize GPUs by removing their UUID
+    return re.sub(uuid_regex, "", out)
+
+
+def get_running_cuda_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, "nvcc --version", r"V(.*)$")
+
+
+def get_cudnn_version(run_lambda):
+    """This will return a list of libcudnn.so; it's hard to tell which one is being used"""
+    if get_platform() == "win32":
+        cudnn_cmd = 'where /R "%CUDA_PATH%\\bin" cudnn*.dll'
+    elif get_platform() == "darwin":
+        # CUDA libraries and drivers can be found in /usr/local/cuda/. See
+        # https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#install
+        # https://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#installmac
+        # Use CUDNN_LIBRARY when cudnn library is installed elsewhere.
+        cudnn_cmd = "ls /usr/local/cuda/lib/libcudnn*"
+    else:
+        cudnn_cmd = 'ldconfig -p | grep libcudnn | rev | cut -d" " -f1 | rev'
+    rc, out, _ = run_lambda(cudnn_cmd)
+    # find will return 1 if there are permission errors or if not found
+    if len(out) == 0 or (rc != 1 and rc != 0):
+        l = os.environ.get("CUDNN_LIBRARY")
+        if l is not None and os.path.isfile(l):
+            return os.path.realpath(l)
+        return None
+    files = set()
+    for fn in out.split("\n"):
+        fn = os.path.realpath(fn)  # eliminate symbolic links
+        if os.path.isfile(fn):
+            files.add(fn)
+    if not files:
+        return None
+    # Alphabetize the result because the order is non-deterministic otherwise
+    files = list(sorted(files))
+    if len(files) == 1:
+        return files[0]
+    result = "\n".join(files)
+    return "Probably one of the following:\n{}".format(result)
+
+
+def get_nvidia_smi():
+    # Note: nvidia-smi is currently available only on Windows and Linux
+    smi = "nvidia-smi"
+    if get_platform() == "win32":
+        smi = '"C:\\Program Files\\NVIDIA Corporation\\NVSMI\\%s"' % smi
+    return smi
+
+
+def get_platform():
+    if sys.platform.startswith("linux"):
+        return "linux"
+    elif sys.platform.startswith("win32"):
+        return "win32"
+    elif sys.platform.startswith("cygwin"):
+        return "cygwin"
+    elif sys.platform.startswith("darwin"):
+        return "darwin"
+    else:
+        return sys.platform
+
+
+def get_mac_version(run_lambda):
+    return run_and_parse_first_match(run_lambda, "sw_vers -productVersion", r"(.*)")
+
+
+def get_windows_version(run_lambda):
+    return run_and_read_all(run_lambda, "wmic os get Caption | findstr /v Caption")
+
+
+def get_lsb_version(run_lambda):
+    return run_and_parse_first_match(
+        run_lambda, "lsb_release -a", r"Description:\t(.*)"
+    )
+
+
+def check_release_file(run_lambda):
+    return run_and_parse_first_match(
+        run_lambda, "cat /etc/*-release", r'PRETTY_NAME="(.*)"'
+    )
+
+
+def get_os(run_lambda):
+    platform = get_platform()
+
+    if platform == "win32" or platform == "cygwin":
+        return get_windows_version(run_lambda)
+
+    if platform == "darwin":
+        version = get_mac_version(run_lambda)
+        if version is None:
+            return None
+        return "Mac OSX {}".format(version)
+
+    if platform == "linux":
+        # Ubuntu/Debian based
+        desc = get_lsb_version(run_lambda)
+        if desc is not None:
+            return desc
+
+        # Try reading /etc/*-release
+        desc = check_release_file(run_lambda)
+        if desc is not None:
+            return desc
+
+        return platform
+
+    # Unknown platform
+    return platform
+
+
+def get_pip_packages(run_lambda):
+    """Returns `pip list` output. Note: will also find conda-installed pytorch
+    and numpy packages."""
+    # People generally have `pip` as `pip` or `pip3`
+    def run_with_pip(pip):
+        if get_platform() == "win32":
+            grep_cmd = r'findstr /R "numpy torch"'
+        else:
+            grep_cmd = r'grep "torch\|numpy"'
+        return run_and_read_all(run_lambda, pip + " list --format=freeze | " + grep_cmd)
+
+    # Try to figure out if the user is running pip or pip3.
+    out2 = run_with_pip("pip")
+    out3 = run_with_pip("pip3")
+
+    num_pips = len([x for x in [out2, out3] if x is not None])
+    if num_pips == 0:
+        return "pip", out2
+
+    if num_pips == 1:
+        if out2 is not None:
+            return "pip", out2
+        return "pip3", out3
+
+    # num_pips is 2. Return pip3 by default b/c that most likely
+    # is the one associated with Python 3
+    return "pip3", out3
+
+
+def get_env_info():
+    run_lambda = run
+    pip_version, pip_list_output = get_pip_packages(run_lambda)
+
+    if TORCH_AVAILABLE:
+        version_str = torch.__version__
+        debug_mode_str = torch.version.debug
+        cuda_available_str = torch.cuda.is_available()
+        cuda_version_str = torch.version.cuda
+    else:
+        version_str = debug_mode_str = cuda_available_str = cuda_version_str = "N/A"
+
+    return SystemEnv(
+        torch_version=version_str,
+        is_debug_build=debug_mode_str,
+        python_version="{}.{}".format(sys.version_info[0], sys.version_info[1]),
+        is_cuda_available=cuda_available_str,
+        cuda_compiled_version=cuda_version_str,
+        cuda_runtime_version=get_running_cuda_version(run_lambda),
+        nvidia_gpu_models=get_gpu_info(run_lambda),
+        nvidia_driver_version=get_nvidia_driver_version(run_lambda),
+        cudnn_version=get_cudnn_version(run_lambda),
+        pip_version=pip_version,
+        pip_packages=pip_list_output,
+        conda_packages=get_conda_packages(run_lambda),
+        os=get_os(run_lambda),
+        gcc_version=get_gcc_version(run_lambda),
+        cmake_version=get_cmake_version(run_lambda),
+    )
+
+
+env_info_fmt = """
+PyTorch version: {torch_version}
+Is debug build: {is_debug_build}
+CUDA used to build PyTorch: {cuda_compiled_version}
+
+OS: {os}
+GCC version: {gcc_version}
+CMake version: {cmake_version}
+
+Python version: {python_version}
+Is CUDA available: {is_cuda_available}
+CUDA runtime version: {cuda_runtime_version}
+GPU models and configuration: {nvidia_gpu_models}
+Nvidia driver version: {nvidia_driver_version}
+cuDNN version: {cudnn_version}
+
+Versions of relevant libraries:
+{pip_packages}
+{conda_packages}
+""".strip()
+
+
+def pretty_str(envinfo):
+    def replace_nones(dct, replacement="Could not collect"):
+        for key in dct.keys():
+            if dct[key] is not None:
+                continue
+            dct[key] = replacement
+        return dct
+
+    def replace_bools(dct, true="Yes", false="No"):
+        for key in dct.keys():
+            if dct[key] is True:
+                dct[key] = true
+            elif dct[key] is False:
+                dct[key] = false
+        return dct
+
+    def prepend(text, tag="[prepend]"):
+        lines = text.split("\n")
+        updated_lines = [tag + line for line in lines]
+        return "\n".join(updated_lines)
+
+    def replace_if_empty(text, replacement="No relevant packages"):
+        if text is not None and len(text) == 0:
+            return replacement
+        return text
+
+    def maybe_start_on_next_line(string):
+        # If `string` is multiline, prepend a \n to it.
+        if string is not None and len(string.split("\n")) > 1:
+            return "\n{}\n".format(string)
+        return string
+
+    mutable_dict = envinfo._asdict()
+
+    # If nvidia_gpu_models is multiline, start on the next line
+    mutable_dict["nvidia_gpu_models"] = maybe_start_on_next_line(
+        envinfo.nvidia_gpu_models
+    )
+
+    # If the machine doesn't have CUDA, report some fields as 'No CUDA'
+    dynamic_cuda_fields = [
+        "cuda_runtime_version",
+        "nvidia_gpu_models",
+        "nvidia_driver_version",
+    ]
+    all_cuda_fields = dynamic_cuda_fields + ["cudnn_version"]
+    all_dynamic_cuda_fields_missing = all(
+        mutable_dict[field] is None for field in dynamic_cuda_fields
+    )
+    if (
+        TORCH_AVAILABLE
+        and not torch.cuda.is_available()
+        and all_dynamic_cuda_fields_missing
+    ):
+        for field in all_cuda_fields:
+            mutable_dict[field] = "No CUDA"
+        if envinfo.cuda_compiled_version is None:
+            mutable_dict["cuda_compiled_version"] = "None"
+
+    # Replace True with Yes, False with No
+    mutable_dict = replace_bools(mutable_dict)
+
+    # Replace all None objects with 'Could not collect'
+    mutable_dict = replace_nones(mutable_dict)
+
+    # If either of these are '', replace with 'No relevant packages'
+    mutable_dict["pip_packages"] = replace_if_empty(mutable_dict["pip_packages"])
+    mutable_dict["conda_packages"] = replace_if_empty(mutable_dict["conda_packages"])
+
+    # Tag conda and pip packages with a prefix
+    # If they were previously None, they'll show up as ie '[conda] Could not collect'
+    if mutable_dict["pip_packages"]:
+        mutable_dict["pip_packages"] = prepend(
+            mutable_dict["pip_packages"], "[{}] ".format(envinfo.pip_version)
+        )
+    if mutable_dict["conda_packages"]:
+        mutable_dict["conda_packages"] = prepend(
+            mutable_dict["conda_packages"], "[conda] "
+        )
+    return env_info_fmt.format(**mutable_dict)
+
+
+def get_pretty_env_info():
+    return pretty_str(get_env_info())
+
+
+def main():
+    print("Collecting environment information...")
+    output = get_pretty_env_info()
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test.py
+++ b/test/test.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 import storch
 from torch.distributions import Normal, Categorical
 import torch
@@ -38,6 +40,7 @@ for i in range(2):
     # plus = lambda a, b: a + b
     # plus = storch.deterministic(plus)
     agg_v = agg_v + s1 + s2 * mu
+    print(isinstance(agg_v, Iterable))
     storch.add_cost(loss(agg_v), "loss")
 
 storch.backward(debug=False, print_costs=True)

--- a/test/test.py
+++ b/test/test.py
@@ -2,6 +2,7 @@ import storch
 from torch.distributions import Normal, Categorical
 import torch
 
+torch.is_tensor = storch.is_tensor
 torch.manual_seed(0)
 
 mu_prior = torch.tensor([2.0, -3.0], requires_grad=True)
@@ -32,6 +33,7 @@ for i in range(2):
         k1 = k[:, 0]
         k2 = k[:, 1]
     s1 = score_method(Normal(mu + k1, 1))
+    aaa = -mu + s1 * k2
     s2 = infer_method(Normal(-mu + s1 * k2, 1))
     # plus = lambda a, b: a + b
     # plus = storch.deterministic(plus)

--- a/test/test_allowed.py
+++ b/test/test_allowed.py
@@ -15,20 +15,19 @@ from storch.exceptions import IllegalStorchExposeError
 method = storch.method.Infer("oeps", Poisson)
 
 d = Normal(0, 1)
-
 s = method.sample(d)
 # print(s>1)
 try:
     if s:
-        print("Oeps")
+        assert False
 except IllegalStorchExposeError:
-    print("Good!!")
+    pass
 
 try:
     if s == s:
-        print("Oeps")
+        assert False
 except IllegalStorchExposeError:
-    print("Good!!")
+    pass
 
 d = Poisson(4)
 s = method.sample(d).int()
@@ -39,5 +38,18 @@ i = 0
 try:
     for _ in range(s):
         i += 1
+    assert False
 except IllegalStorchExposeError:
-    print("Good!")
+    pass
+
+try:
+    if torch.allclose(s, s):
+        assert False
+except IllegalStorchExposeError:
+    pass
+
+try:
+    if s.allclose(s):
+        assert False
+except IllegalStorchExposeError:
+    pass

--- a/test/test_allowed.py
+++ b/test/test_allowed.py
@@ -1,20 +1,22 @@
 import torch
-a = torch.tensor([[[[1., .4,.6, .9], [5., 4., 3., .2]]]])
+
+a = torch.tensor([[[[1.0, 0.4, 0.6, 0.9], [5.0, 4.0, 3.0, 0.2]]]])
 b = torch.tensor([[[[True, False, True, False], [True, False, True, False]]]])
 
 import storch
+
 print(torch.Tensor.__getitem__(a, b))
 print(a[b])
-a[b] = 10.
+a[b] = 10.0
 print(a)
 from torch.distributions import Normal, Categorical, Poisson
 from storch.exceptions import IllegalStorchExposeError
 
-method = storch.method.Infer(Poisson)
+method = storch.method.Infer("oeps", Poisson)
 
 d = Normal(0, 1)
 
-s = method.sample("oeps", d)
+s = method.sample(d)
 # print(s>1)
 try:
     if s:
@@ -22,14 +24,20 @@ try:
 except IllegalStorchExposeError:
     print("Good!!")
 
-if s == s:
-    print("ahh good")
+try:
+    if s == s:
+        print("Oeps")
+except IllegalStorchExposeError:
+    print("Good!!")
 
 d = Poisson(4)
-s = method.sample(d)
+s = method.sample(d).int()
 
 print(s)
 
 i = 0
-for _ in range(s):
-    i += 1
+try:
+    for _ in range(s):
+        i += 1
+except IllegalStorchExposeError:
+    print("Good!")

--- a/test/test_broadcast_all.py
+++ b/test/test_broadcast_all.py
@@ -1,0 +1,11 @@
+import torch
+
+
+class TensorLike:
+    def __torch_function__(func, types, args=(), kwargs=None):
+        print("In __torch_function_")
+
+
+from torch.distributions import Normal
+
+Normal(loc=TensorLike(), scale=1)

--- a/test/test_swr.py
+++ b/test/test_swr.py
@@ -2,6 +2,7 @@ import storch
 from torch.distributions import Normal, OneHotCategorical
 import torch
 
+torch.is_tensor = storch.is_tensor
 torch.manual_seed(0)
 
 # LEGEND OF SHAPES


### PR DESCRIPTION
Now that PyTorch 1.5 introduced the `__torch_function__` magic method that is called when torch functions are called with Tensor-likes, we can wrap around PyTorch much cleaner. 

This branch removes the earlier monkey patching design in favour of this `__torch_function__` design. Quick tests show that this design works very well. One caveat is in creating Distributions using storch Tensors. The `broadcast_all` method does not support Tensor-likes, and requires monkey patching either that method or `torch.is_tensor`.

Closes #59. 