### PR TITLE
Abstracted sampling out of storch.method.Method

### DIFF
--- a/storch/__init__.py
+++ b/storch/__init__.py
@@ -1,5 +1,3 @@
-_debug = False
-
 from .wrappers import (
     deterministic,
     stochastic,
@@ -9,14 +7,17 @@ from .wrappers import (
     ignore_wrapping,
 )
 from .tensor import Tensor, CostTensor, StochasticTensor, Plate, is_tensor
-from .method import *
+import storch.sampling
+import storch.method
 from .inference import backward, add_cost, reset, denote_independent, gather_samples
 from .util import print_graph
 from .storch import *
 import storch.typing
 import storch.nn
 
-import torch
 
-torch.is_tensor = storch.is_tensor
-torch.Tensor.to = deterministic(torch.Tensor.to)
+import torch as _torch
+
+_debug = False
+_torch.is_tensor = storch.is_tensor
+_torch.Tensor.to = deterministic(_torch.Tensor.to)

--- a/storch/inference.py
+++ b/storch/inference.py
@@ -140,12 +140,14 @@ def backward(retain_graph=False, debug=False, print_costs=False) -> torch.Tensor
             parent_tensor = parent._tensor
             reduced_cost = c
             parent_plates = parent.multi_dim_plates()
-
+            print("----------")
+            print(reduced_cost.plates)
             # Reduce all plates that are in the cost node but not in the parent node
             for plate in storch.order_plates(c.multi_dim_plates(), reverse=True):
+                print(plate)
                 if plate not in parent_plates:
                     reduced_cost = plate.reduce(reduced_cost, detach_weights=True)
-
+                    print(reduced_cost.plates)
             # Align the parent tensor so that the plate dimensions are in the same order as the cost tensor
             for index_c, plate in enumerate(reduced_cost.multi_dim_plates()):
                 index_p = parent_plates.index(plate)

--- a/storch/inference.py
+++ b/storch/inference.py
@@ -7,7 +7,7 @@ import storch
 
 
 _cost_tensors: [CostTensor] = []
-_sampling_methods: [storch.Method] = []
+_sampling_methods: [storch.method.Method] = []
 
 
 def denote_independent(
@@ -140,14 +140,10 @@ def backward(retain_graph=False, debug=False, print_costs=False) -> torch.Tensor
             parent_tensor = parent._tensor
             reduced_cost = c
             parent_plates = parent.multi_dim_plates()
-            print("----------")
-            print(reduced_cost.plates)
             # Reduce all plates that are in the cost node but not in the parent node
             for plate in storch.order_plates(c.multi_dim_plates(), reverse=True):
-                print(plate)
                 if plate not in parent_plates:
                     reduced_cost = plate.reduce(reduced_cost, detach_weights=True)
-                    print(reduced_cost.plates)
             # Align the parent tensor so that the plate dimensions are in the same order as the cost tensor
             for index_c, plate in enumerate(reduced_cost.multi_dim_plates()):
                 index_p = parent_plates.index(plate)

--- a/storch/method/__init__.py
+++ b/storch/method/__init__.py
@@ -5,10 +5,8 @@ from storch.method.method import (
     Method,
     Expect,
     Reparameterization,
-    MonteCarloMethod,
 )
 from storch.method.relax import RELAX, REBAR, LAX
 from storch.method.baseline import Baseline, MovingAverageBaseline
-from storch.method.sampling import SampleWithoutReplacementMethod
 from storch.method.multi_sample_reinforce import ScoreFunctionWOR
 from storch.method.unordered import UnorderedSetEstimator

--- a/storch/method/method.py
+++ b/storch/method/method.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from torch.distributions import Distribution, OneHotCategorical, Bernoulli, Categorical
 
 from storch.tensor import CostTensor, StochasticTensor, Plate
@@ -9,10 +9,14 @@ from storch.util import (
     get_distr_parameters,
     rsample_gumbel,
 )
-from storch.typing import DiscreteDistribution, BaselineFactory
+from storch.typing import BaselineFactory
 import storch
 from storch.method.baseline import MovingAverageBaseline, BatchAverageBaseline
-import itertools
+from storch.sampling import (
+    SamplingMethod,
+    MonteCarlo,
+    Enumerate,
+)
 
 
 class Method(ABC, torch.nn.Module):
@@ -27,11 +31,16 @@ class Method(ABC, torch.nn.Module):
 
     """
 
-    def __init__(self, plate_name):
+    def __init__(self, plate_name: str, sampling_method: SamplingMethod):
         super().__init__()
         self._estimation_pairs = []
         self.register_buffer("iterations", torch.tensor(0, dtype=torch.long))
         self.plate_name = plate_name
+        self.sampling_method = sampling_method
+        if not self.sampling_method.plate_name == plate_name:
+            raise ValueError(
+                "The plate name of the sampling method and the storch method should match."
+            )
 
     def forward(self, distr: Distribution) -> storch.tensor.StochasticTensor:
         """
@@ -95,11 +104,14 @@ class Method(ABC, torch.nn.Module):
 
         for plate in plates:
             if plate.name == self.plate_name:
-                self.on_plate_already_present(plate)
+                self.sampling_method.on_plate_already_present(plate)
 
-        s_tensor, plate = self._sample_tensor(distr, parents, plates, requires_grad)
+        s_tensor: StochasticTensor
+        s_tensor, plate = self.sampling_method(distr, parents, plates, requires_grad)
 
-        batch_weighting = self.plate_weighting(s_tensor, plate)
+        s_tensor._set_method(self)
+
+        batch_weighting = self.sampling_method.plate_weighting(s_tensor, plate)
         if batch_weighting is not None:
             plate.weight = batch_weighting
             # TODO: I don't think this code should be here.
@@ -147,7 +159,6 @@ class Method(ABC, torch.nn.Module):
                 s_tensor.plates,
                 s_tensor.name,
                 s_tensor.n,
-                None,
                 s_tensor.distribution,
                 False,
             )
@@ -172,16 +183,6 @@ class Method(ABC, torch.nn.Module):
         self.update_parameters(self._estimation_pairs)
         self._estimation_pairs = []
 
-    @abstractmethod
-    def _sample_tensor(
-        self,
-        distr: Distribution,
-        parents: [storch.Tensor],
-        plates: [Plate],
-        requires_grad: bool,
-    ) -> (storch.StochasticTensor, Plate):
-        pass
-
     def estimator(
         self, tensor: StochasticTensor, cost_node: CostTensor
     ) -> Optional[storch.Tensor]:
@@ -194,14 +195,6 @@ class Method(ABC, torch.nn.Module):
         self, result_triples: [(StochasticTensor, CostTensor)]
     ) -> None:
         pass
-
-    def plate_weighting(
-        self, tensor: storch.StochasticTensor, plate: Plate
-    ) -> Optional[storch.Tensor]:
-        # Weight by the size of the sample. Overload this if your gradient estimation uses some kind of weighting
-        # of the different events, like importance sampling or computing the expectation.
-        # If None is returned, it is assumed the samples are iid monte carlo samples.
-        return None
 
     def adds_loss(self, tensor: StochasticTensor, cost_node: CostTensor) -> bool:
         """
@@ -218,86 +211,32 @@ class Method(ABC, torch.nn.Module):
         This function gets called whenever storchastic is reset. This is after storch.backward() or storch.reset() is
         called. Can be used to reset this methods state to some initial state that has to happen every iteration. 
         """
-        pass
-
-    def on_plate_already_present(self, plate: Plate):
-        raise ValueError(
-            "Cannot create stochastic tensor with name "
-            + plate.name
-            + ". A parent sample has already used this name. Use a different name for this sample."
-        )
+        self.sampling_method.reset()
 
 
-# For monte carlo sampled methods
-class MonteCarloMethod(Method):
-    """
-    Monte Carlo methods use simple sampling methods that take n independent samples.
-    Unlike complex ancestral sampling methods such as SampleWithoutReplacementMethod, the sampling behaviour is not dependent
-    on earlier samples in the stochastic computation graph (but the distributions are!).
-    """
-
-    def __init__(self, plate_name: str, n_samples: int = 1):
-        super().__init__(plate_name)
-        self.n_samples = n_samples
-
-    def _sample_tensor(
-        self,
-        distr: Distribution,
-        parents: [storch.Tensor],
-        plates: [Plate],
-        requires_grad: bool,
-    ) -> (storch.StochasticTensor, Plate):
-        tensor = self.mc_sample(distr, parents, plates)
-        plate_size = tensor.shape[0]
-        if tensor.shape[0] == 1:
-            tensor = tensor.squeeze(0)
-
-        plate = Plate(self.plate_name, plate_size, plates.copy())
-        plates.insert(0, plate)
-
-        if isinstance(tensor, storch.Tensor):
-            tensor = tensor._tensor
-
-        s_tensor = StochasticTensor(
-            tensor,
-            parents,
-            plates,
-            self.plate_name,
-            plate_size,
-            self,
-            distr,
-            requires_grad,
-        )
-        return s_tensor, plate
-
-    @abstractmethod
-    def mc_sample(self, distr: Distribution, parents: [storch.Tensor], plates: [Plate]):
-        pass
-
-
-class Infer(MonteCarloMethod):
+class Infer(Method):
     """
     Method that automatically chooses reparameterization if it is available, otherwise the score function.
     """
 
     def __init__(
-        self, plate_name: str, distribution_type: Type[Distribution], n_samples: int = 1
+        self,
+        plate_name: str,
+        distribution_type: Type[Distribution],
+        sampling_method: Optional[SamplingMethod] = None,
+        n_samples: int = 1,
     ):
-        super().__init__(plate_name, n_samples)
         if distribution_type.has_rsample:
-            self._method = Reparameterization(plate_name, n_samples)
+            _method = Reparameterization(plate_name, sampling_method, n_samples)
         elif issubclass(distribution_type, OneHotCategorical) or issubclass(
             distribution_type, Bernoulli
         ):
-            self._method = GumbelSoftmax(plate_name, n_samples)
+            _method = GumbelSoftmax(plate_name, sampling_method, n_samples)
         else:
-            self._method = ScoreFunction(plate_name, n_samples)
-        self._score_method = ScoreFunction(plate_name, n_samples)
-
-    def mc_sample(
-        self, distr: Distribution, parents: [storch.Tensor], plates: [Plate]
-    ) -> torch.Tensor:
-        return self._method.mc_sample(distr, parents, plates)
+            _method = ScoreFunction(plate_name, sampling_method, n_samples)
+        super().__init__(plate_name, _method.sampling_method)
+        self._score_method = ScoreFunction(plate_name, sampling_method, n_samples)
+        self._method = _method
 
     def estimator(
         self, tensor: StochasticTensor, cost_node: CostTensor
@@ -319,22 +258,85 @@ class Infer(MonteCarloMethod):
             return True
 
 
-class Reparameterization(MonteCarloMethod):
+class Reparameterization(Method):
     """
     Can only be used for reparameterizable distributions.
     Default option for reparameterizable distributions.
     """
 
-    def mc_sample(
-        self, distr: Distribution, parents: [storch.Tensor], plates: [Plate]
-    ) -> torch.Tensor:
+    def __init__(
+        self,
+        plate_name: str,
+        sampling_method: Optional[SamplingMethod] = None,
+        n_samples: int = 1,
+    ):
+        if not sampling_method:
+            sampling_method = MonteCarlo(plate_name, n_samples)
+        super().__init__(plate_name, sampling_method.set_mc_sample(self.reparam_sample))
+
+    def adds_loss(self, tensor: StochasticTensor, cost_node: CostTensor) -> bool:
+        if has_differentiable_path(cost_node, tensor):
+            # There is a differentiable path, so we will just use reparameterization here.
+            return False
+        raise ValueError(
+            "There is no differentiable path between the cost tensor and the stochastic tensor. "
+            "We cannot use reparameterization. Use a different gradient estimator, or make sure your"
+            "code is differentiable."
+        )
+
+    def reparam_sample(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        amt_samples: int,
+    ):
         if not distr.has_rsample:
             raise ValueError(
                 "The input distribution has not implemented rsample. If you use a discrete "
                 "distribution, make sure to use eg GumbelSoftmax."
             )
-        with storch.ignore_wrapping():
-            return distr.rsample((self.n_samples,))
+        return distr.rsample((amt_samples,))
+
+
+class GumbelSoftmax(Method):
+    """
+    Method that automatically chooses between Gumbel Softmax relaxation and the score function depending on the
+    differentiability requirements of cost nodes. Can only be used for reparameterizable distributions.
+    Default option for reparameterizable distributions.
+    """
+
+    def __init__(
+        self,
+        plate_name: str,
+        sampling_method: Optional[SamplingMethod] = None,
+        n_samples: int = 1,
+        straight_through=False,
+        initial_temperature=1.0,
+        min_temperature=1.0e-4,
+        annealing_rate=1.0e-5,
+    ):
+        if not sampling_method:
+            sampling_method = MonteCarlo(plate_name, n_samples)
+        super().__init__(
+            plate_name, sampling_method.set_mc_sample(self.sample_gumbel),
+        )
+
+        self.straight_through = straight_through
+        self.register_buffer("temperature", torch.tensor(initial_temperature))
+        self.register_buffer("annealing_rate", torch.tensor(annealing_rate))
+        self.register_buffer("min_temperature", torch.tensor(min_temperature))
+
+    def sample_gumbel(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        amt_samples: int,
+    ):
+        return rsample_gumbel(
+            distr, amt_samples, self.temperature, self.straight_through
+        )
 
     def adds_loss(self, tensor: StochasticTensor, cost_node: CostTensor) -> bool:
         if has_differentiable_path(cost_node, tensor):
@@ -347,54 +349,18 @@ class Reparameterization(MonteCarloMethod):
         )
 
 
-class GumbelSoftmax(Reparameterization):
-    """
-    Method that automatically chooses between Gumbel Softmax relaxation and the score function depending on the
-    differentiability requirements of cost nodes. Can only be used for reparameterizable distributions.
-    Default option for reparameterizable distributions.
-    """
-
+class ScoreFunction(Method):
     def __init__(
         self,
         plate_name: str,
-        n_samples: int = 1,
-        straight_through=False,
-        initial_temperature=1.0,
-        min_temperature=1.0e-4,
-        annealing_rate=1.0e-5,
-    ):
-        super().__init__(plate_name, n_samples)
-        self.straight_through = straight_through
-        self.register_buffer("temperature", torch.tensor(initial_temperature))
-        self.register_buffer("annealing_rate", torch.tensor(annealing_rate))
-        self.register_buffer("min_temperature", torch.tensor(min_temperature))
-
-    def mc_sample(
-        self, distr: DiscreteDistribution, parents: [storch.Tensor], plates: [Plate],
-    ) -> torch.Tensor:
-        with storch.ignore_wrapping():
-            return rsample_gumbel(
-                distr, self.n_samples, self.temperature, self.straight_through
-            )
-
-    def update_parameters(
-        self, result_triples: [(StochasticTensor, CostTensor, torch.Tensor)]
-    ):
-        if self.training:
-            self.temperature = torch.max(
-                self.min_temperature, torch.exp(-self.annealing_rate * self.iterations)
-            )
-
-
-class ScoreFunction(MonteCarloMethod):
-    def __init__(
-        self,
-        plate_name: str,
+        sampling_method: Optional[SamplingMethod] = None,
         n_samples: int = 1,
         baseline_factory: Optional[Union[BaselineFactory, str]] = "moving_average",
         **kwargs,
     ):
-        super().__init__(plate_name, n_samples)
+        if not sampling_method:
+            sampling_method = MonteCarlo(plate_name, n_samples)
+        super().__init__(plate_name, sampling_method)
         self.baseline_factory: Optional[BaselineFactory] = baseline_factory
         if isinstance(baseline_factory, str):
             if baseline_factory == "moving_average":
@@ -410,12 +376,6 @@ class ScoreFunction(MonteCarloMethod):
                 self.baseline_factory = None
             else:
                 raise ValueError("Invalid baseline name", baseline_factory)
-
-    def mc_sample(
-        self, distr: Distribution, parents: [storch.Tensor], plates: [Plate]
-    ) -> torch.Tensor:
-        with storch.ignore_wrapping():
-            return distr.sample((self.n_samples,))
 
     def estimator(self, tensor: StochasticTensor, cost: CostTensor) -> storch.Tensor:
         log_prob = tensor.distribution.log_prob(tensor)
@@ -440,79 +400,4 @@ class ScoreFunction(MonteCarloMethod):
 
 class Expect(Method):
     def __init__(self, plate_name: str, budget=10000):
-        super().__init__(plate_name)
-        self.budget = budget
-
-    def _sample_tensor(
-        self,
-        distr: Distribution,
-        parents: [storch.Tensor],
-        plates: [Plate],
-        requires_grad: bool,
-    ) -> (storch.StochasticTensor, Plate):
-        # TODO: Currently very inefficient as it isn't batched
-        # TODO: What if the expectation has a parent
-        if not distr.has_enumerate_support:
-            raise ValueError(
-                "Can only calculate the expected value for distributions with enumerable support."
-            )
-        support: torch.Tensor = distr.enumerate_support(expand=True)
-        support_non_expanded: torch.Tensor = distr.enumerate_support(expand=False)
-        expect_size = support.shape[0]
-
-        batch_len = len(plates)
-        sizes = support.shape[
-            batch_len + 1 : len(support.shape) - len(distr.event_shape)
-        ]
-        amt_samples_used = expect_size
-        cross_products = 1 if not sizes else None
-        for dim in sizes:
-            amt_samples_used = amt_samples_used ** dim
-            if not cross_products:
-                cross_products = dim
-            else:
-                cross_products = cross_products ** dim
-
-        if amt_samples_used > self.budget:
-            raise ValueError(
-                "Computing the expectation on this distribution would exceed the computation budget."
-            )
-
-        enumerate_tensor = support.new_zeros(
-            [amt_samples_used] + list(support.shape[1:])
-        )
-        support_non_expanded = support_non_expanded.squeeze().unsqueeze(1)
-        for i, t in enumerate(
-            itertools.product(support_non_expanded, repeat=cross_products)
-        ):
-            enumerate_tensor[i] = torch.cat(t, dim=0)
-
-        enumerate_tensor = enumerate_tensor.detach()
-
-        plate_size = enumerate_tensor.shape[0]
-
-        plate = Plate(self.plate_name, plate_size, plates.copy())
-        plates.insert(0, plate)
-
-        s_tensor = StochasticTensor(
-            enumerate_tensor,
-            parents,
-            plates,
-            self.plate_name,
-            plate_size,
-            self,
-            distr,
-            requires_grad,
-        )
-        return s_tensor, plate
-
-    def plate_weighting(
-        self, tensor: storch.StochasticTensor, plate: Plate
-    ) -> Optional[storch.Tensor]:
-        # Weight by the probability of each possible event
-        log_probs = tensor.distribution.log_prob(tensor)
-        if log_probs.plate_dims < len(log_probs.shape):
-            log_probs = log_probs.sum(
-                dim=list(range(tensor.plate_dims, len(log_probs.shape)))
-            )
-        return log_probs.exp()
+        super().__init__(plate_name, Enumerate(plate_name, budget))

--- a/storch/method/method.py
+++ b/storch/method/method.py
@@ -216,7 +216,8 @@ class Method(ABC, torch.nn.Module):
 
 class Infer(Method):
     """
-    Method that automatically chooses reparameterization if it is available, otherwise the score function.
+    Method that automatically chooses reparameterization if it is available, and otherwise the score function
+    with appropriate baseline (moving average if n_samples = 1, else batch average).
     """
 
     def __init__(
@@ -233,7 +234,14 @@ class Infer(Method):
         ):
             _method = GumbelSoftmax(plate_name, sampling_method, n_samples)
         else:
-            _method = ScoreFunction(plate_name, sampling_method, n_samples)
+            _method = ScoreFunction(
+                plate_name,
+                sampling_method,
+                n_samples,
+                baseline_factory="moving_average"
+                if n_samples == 1
+                else "batch_average",
+            )
         super().__init__(plate_name, _method.sampling_method)
         self._score_method = ScoreFunction(plate_name, sampling_method, n_samples)
         self._method = _method

--- a/storch/method/multi_sample_reinforce.py
+++ b/storch/method/multi_sample_reinforce.py
@@ -1,12 +1,12 @@
 from typing import Optional
 
-import torch
 import storch
+from storch.method.method import Method
 
-from storch.method.sampling import SampleWithoutReplacementMethod, AncestralPlate
+from storch.sampling import SampleWithoutReplacement
 
 
-class ScoreFunctionWOR(SampleWithoutReplacementMethod):
+class ScoreFunctionWOR(Method):
     """
     Implement Buy 4 REINFORCE Samples, Get a Baseline for Free! https://openreview.net/pdf?id=r1lgTGL5DE
     Use biased=True for the biased normalized version which has lower variance.
@@ -18,34 +18,9 @@ class ScoreFunctionWOR(SampleWithoutReplacementMethod):
         self, plate_name: str, k: int, biased: bool = True, use_baseline: bool = True
     ):
         # Use k + 1 to be able to compute kappa, the k+1th perturbed log-prob
-        super().__init__(plate_name, k + 1)
+        super().__init__(plate_name, SampleWithoutReplacement(plate_name, k, biased))
         self.biased = biased
         self.use_baseline = use_baseline
-
-    def plate_weighting(
-        self, tensor: storch.StochasticTensor, plate: storch.Plate
-    ) -> Optional[storch.Tensor]:
-        return self._compute_iw(plate, self.biased).detach()
-
-    def _compute_iw(self, plate: AncestralPlate, biased: bool):
-        # Compute importance weights. The kth sample has 0 weight, and is only used to compute the importance weights
-        q = (
-            1
-            - (
-                -(
-                    plate.log_probs
-                    - plate.perturb_log_probs._tensor[..., self.k - 1].unsqueeze(-1)
-                ).exp()
-            ).exp()
-        ).detach()
-        iw = plate.log_probs.exp() / (q + self.EPS)
-        # It's probably not going to like this? Would iw._tensor work?
-        # Set the weight of the kth sample (kappa) to 0.
-        iw[..., self.k - 1] = 0.0
-        if biased:
-            WS = storch.sum(iw, plate).detach()
-            return iw / WS
-        return iw
 
     def adds_loss(
         self, tensor: storch.StochasticTensor, cost_node: storch.CostTensor
@@ -75,7 +50,7 @@ class ScoreFunctionWOR(SampleWithoutReplacementMethod):
                 cost_plate = _p
                 break
         if self.use_baseline:
-            iw = self._compute_iw(cost_plate, biased=False)
+            iw = self.sampling_method.compute_iw(cost_plate, biased=False)
             BS = storch.sum(iw * cost_node, cost_plate)
             probs = cost_plate.log_probs.exp()
             if self.biased:
@@ -91,5 +66,6 @@ class ScoreFunctionWOR(SampleWithoutReplacementMethod):
                 return storch.sum(iw * diff_cost.detach(), cost_plate)
         else:
             # Equation 9
-            iw = self._compute_iw(cost_plate, self.biased)
+            # TODO: This seems inefficient... The plate should already contain the IW, right? Same for above if not self.biased
+            iw = self.sampling_method.compute_iw(cost_plate, self.biased)
             return storch.sum(cost_node.detach() * iw, self.plate_name)

--- a/storch/method/multi_sample_reinforce.py
+++ b/storch/method/multi_sample_reinforce.py
@@ -12,8 +12,6 @@ class ScoreFunctionWOR(Method):
     Use biased=True for the biased normalized version which has lower variance.
     """
 
-    EPS = 1e-8
-
     def __init__(
         self, plate_name: str, k: int, biased: bool = True, use_baseline: bool = True
     ):

--- a/storch/method/relax.py
+++ b/storch/method/relax.py
@@ -51,6 +51,14 @@ class LAX(Reparameterization):
         c_phi: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         in_dim=None,
     ):
+        """
+        Either c_phi or in_dim needs to be non-None!
+        :param plate_name: Name of the plate
+        :param sampling_method: The sampling method to use
+        :param n_samples: The amount of samples to take
+        :param c_phi: The baseline network. Needs to be specified if `in_dim`  is not specified.
+        :param in_dim: The size of the default baseline. Needs to be set if `c_phi` is not specified.
+        """
         super().__init__(plate_name, sampling_method, n_samples)
         if c_phi:
             self.c_phi = c_phi

--- a/storch/method/relax.py
+++ b/storch/method/relax.py
@@ -9,8 +9,9 @@ from torch.nn import Parameter
 
 import storch
 from storch import Plate, CostTensor, StochasticTensor, deterministic
-from storch.method.method import MonteCarloMethod
+from storch.sampling import MonteCarlo, SamplingMethod
 from storch.typing import Dims
+from storch.method.method import Reparameterization, GumbelSoftmax
 
 import torch.nn.functional as F
 
@@ -34,7 +35,7 @@ class Baseline(torch.nn.Module):
         return self.fc2(F.relu(self.fc1(x))).squeeze(-1)
 
 
-class LAX(MonteCarloMethod):
+class LAX(Reparameterization):
     """
     Gradient estimator for continuous random variables.
     Implements the LAX estimator from Grathwohl et al, 2018 https://arxiv.org/abs/1711.00123
@@ -45,24 +46,23 @@ class LAX(MonteCarloMethod):
         self,
         plate_name: str,
         *,
+        sampling_method: Optional[SamplingMethod] = None,
         n_samples: int = 1,
         c_phi: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         in_dim=None,
     ):
-        super().__init__(plate_name, n_samples)
+        super().__init__(plate_name, sampling_method, n_samples)
         if c_phi:
             self.c_phi = c_phi
         else:
             self.c_phi = Baseline(in_dim)
         # TODO: Add baseline strength
 
-    def mc_sample(
-        self, distr: Distribution, parents: [storch.Tensor], plates: [Plate]
-    ) -> torch.Tensor:
-        sample = distr.rsample((self.n_samples,))
-        return sample
-
     def post_sample(self, tensor: storch.StochasticTensor) -> Optional[storch.Tensor]:
+        """
+        We do a reparameterized sample, but we have to make sure we detach afterwards. The rsample is to make sure we
+        can backpropagate through the sample in the estimator.
+        """
         return tensor.detach()
 
     def estimator(
@@ -125,7 +125,61 @@ class LAX(MonteCarloMethod):
         return True
 
 
-class RELAX(MonteCarloMethod):
+def discretize(tensor: torch.Tensor, distr: Distribution) -> torch.Tensor:
+    # Adapted from pyro.relaxed_straight_through
+    if isinstance(distr, Bernoulli):
+        return tensor.round()
+    argmax = tensor.max(-1)[1]
+    hard_sample = torch.zeros_like(tensor)
+    if argmax.dim() < hard_sample.dim():
+        argmax = argmax.unsqueeze(-1)
+    return hard_sample.scatter_(-1, argmax, 1)
+
+
+@deterministic
+def conditional_gumbel_rsample(
+    hard_sample: torch.Tensor, distr: Distribution, temperature,
+) -> torch.Tensor:
+    """
+    Conditionally re-samples from the distribution given the hard sample.
+    This samples z \sim p(z|b), where b is the hard sample and p(z) is a gumbel distribution.
+    """
+    # Adapted from torch.distributions.relaxed_bernoulli and torch.distributions.relaxed_categorical
+    shape = hard_sample.shape
+    probs = (
+        distr.probs
+        if not isinstance(hard_sample, storch.Tensor)
+        else distr.probs._tensor
+    )
+    probs = clamp_probs(probs.expand_as(hard_sample))
+    v = clamp_probs(torch.rand(shape, dtype=probs.dtype, device=probs.device))
+    if isinstance(distr, Bernoulli):
+        pos_probs = probs[hard_sample == 1]
+        v_prime = torch.zeros_like(hard_sample)
+        # See https://arxiv.org/abs/1711.00123
+        v_prime[hard_sample == 1] = v[hard_sample == 1] * pos_probs + (1 - pos_probs)
+        v_prime[hard_sample == 0] = v[hard_sample == 0] * (1 - probs[hard_sample == 0])
+        log_sample = (
+            probs.log() + probs.log1p() + v_prime.log() + v_prime.log1p()
+        ) / temperature
+        return log_sample.sigmoid()
+    # b=argmax(hard_sample)
+    b = hard_sample.max(-1).indices
+    # b = F.one_hot(b, hard_sample.shape[-1])
+
+    # See https://arxiv.org/abs/1711.00123
+    log_v = v.log()
+    # i != b (indexing could maybe be improved here, but i doubt it'd be more efficient)
+    log_v_b = torch.gather(log_v, -1, b.unsqueeze(-1))
+    cond_gumbels = -(-(log_v / probs) - log_v_b).log()
+    # i = b
+    index_sample = hard_sample.bool()
+    cond_gumbels[index_sample] = -(-log_v[index_sample]).log()
+    scores = cond_gumbels / temperature
+    return (scores - scores.logsumexp(dim=-1, keepdim=True)).exp()
+
+
+class RELAX(GumbelSoftmax):
     """
     Gradient estimator for Bernoulli and Categorical distributions on any function.
     Implements the RELAX estimator from Grathwohl et al, 2018, https://arxiv.org/abs/1711.00123
@@ -137,35 +191,26 @@ class RELAX(MonteCarloMethod):
         self,
         plate_name: str,
         *,
+        sampling_method: Optional[SamplingMethod] = None,
         n_samples: int = 1,
         c_phi: Callable[[torch.Tensor], torch.Tensor] = None,
         in_dim: Dims = None,
         rebar=False,
     ):
-        super().__init__(plate_name, n_samples)
+        if not sampling_method:
+            sampling_method = MonteCarlo(plate_name, n_samples)
+        super().__init__(plate_name, sampling_method.set_mc_sample(self.mc_sample))
         if c_phi:
             self.c_phi = c_phi
         else:
             self.c_phi = Baseline(in_dim)
-        self.rebar = rebar
+
         self.temperature = Parameter(torch.tensor(1.0))
+        self.rebar = rebar
+        if self.rebar:
+            self.sampling_method = REBARMC(plate_name, n_samples, self.temperature)
         # TODO: Automatically learn eta
         self.eta = 1.0
-
-    def mc_sample(
-        self, distr: Distribution, parents: [storch.Tensor], plates: [Plate]
-    ) -> torch.Tensor:
-        relaxed_sample = rsample_gumbel(
-            distr, self.n_samples, self.temperature, straight_through=False
-        )
-        # In REBAR, the objective function is evaluated for the Gumbel sample, the conditional Gumbel sample \tilde{z} and the argmax of the Gumbel sample.
-        if self.rebar:
-            hard_sample = self._discretize(relaxed_sample, distr)
-            cond_sample = self._conditional_gumbel_rsample(hard_sample, distr)
-            return torch.cat([hard_sample, relaxed_sample, cond_sample], 0)
-        else:
-            return relaxed_sample
-        # sample relaxed if not rebar else sample z then return -> (H(z), z, z|H(z) and n*3
 
     def post_sample(self, tensor: storch.StochasticTensor) -> Optional[storch.Tensor]:
         if self.rebar:
@@ -178,74 +223,6 @@ class RELAX(MonteCarloMethod):
             # Return H(z) for the function evaluation if using RELAX
             return self._discretize(tensor, tensor.distribution)
 
-    def plate_weighting(
-        self, tensor: storch.StochasticTensor, plate: storch.Plate
-    ) -> Optional[storch.Tensor]:
-        # if REBAR: only weight over the true samples, put the relaxed samples to weight 0. This also makes sure
-        # that they will not be backpropagated through in the cost backwards pass
-        if self.rebar:
-            n = int(tensor.n / 3)
-            weighting = tensor.new_zeros((3 * n,))
-            weighting[:n] = tensor.new_tensor(1.0 / n)
-            return weighting
-        return super().plate_weighting(tensor, plate)
-
-    def _discretize(self, tensor: torch.Tensor, distr: Distribution) -> torch.Tensor:
-        # Adapted from pyro.relaxed_straight_through
-        if isinstance(distr, Bernoulli):
-            return tensor.round()
-        argmax = tensor.max(-1)[1]
-        hard_sample = torch.zeros_like(tensor)
-        if argmax.dim() < hard_sample.dim():
-            argmax = argmax.unsqueeze(-1)
-        return hard_sample.scatter_(-1, argmax, 1)
-
-    @deterministic
-    def _conditional_gumbel_rsample(
-        self, hard_sample: torch.Tensor, distr: Distribution
-    ) -> torch.Tensor:
-        """
-        Conditionally re-samples from the distribution given the hard sample.
-        This samples z \sim p(z|b), where b is the hard sample and p(z) is a gumbel distribution.
-        """
-        # Adapted from torch.distributions.relaxed_bernoulli and torch.distributions.relaxed_categorical
-        shape = hard_sample.shape
-        probs = (
-            distr.probs
-            if not isinstance(hard_sample, storch.Tensor)
-            else distr.probs._tensor
-        )
-        probs = clamp_probs(probs.expand_as(hard_sample))
-        v = clamp_probs(torch.rand(shape, dtype=probs.dtype, device=probs.device))
-        if isinstance(distr, Bernoulli):
-            pos_probs = probs[hard_sample == 1]
-            v_prime = torch.zeros_like(hard_sample)
-            # See https://arxiv.org/abs/1711.00123
-            v_prime[hard_sample == 1] = v[hard_sample == 1] * pos_probs + (
-                1 - pos_probs
-            )
-            v_prime[hard_sample == 0] = v[hard_sample == 0] * (
-                1 - probs[hard_sample == 0]
-            )
-            log_sample = (
-                probs.log() + probs.log1p() + v_prime.log() + v_prime.log1p()
-            ) / self.temperature
-            return log_sample.sigmoid()
-        # b=argmax(hard_sample)
-        b = hard_sample.max(-1).indices
-        # b = F.one_hot(b, hard_sample.shape[-1])
-
-        # See https://arxiv.org/abs/1711.00123
-        log_v = v.log()
-        # i != b (indexing could maybe be improved here, but i doubt it'd be more efficient)
-        log_v_b = torch.gather(log_v, -1, b.unsqueeze(-1))
-        cond_gumbels = -(-(log_v / probs) - log_v_b).log()
-        # i = b
-        index_sample = hard_sample.bool()
-        cond_gumbels[index_sample] = -(-log_v[index_sample]).log()
-        scores = cond_gumbels / self.temperature
-        return (scores - scores.logsumexp(dim=-1, keepdim=True)).exp()
-
     def estimator(
         self, tensor: StochasticTensor, cost_node: CostTensor
     ) -> Optional[storch.Tensor]:
@@ -257,10 +234,10 @@ class RELAX(MonteCarloMethod):
             hard_cost, relaxed_cost, cond_cost = split(cost_node, plate, amt_slices=3)
 
         else:
-            hard_sample = self._discretize(tensor, tensor.distribution)
+            hard_sample = discretize(tensor, tensor.distribution)
             relaxed_sample = tensor
-            cond_sample = self._conditional_gumbel_rsample(
-                hard_sample, tensor.distribution
+            cond_sample = conditional_gumbel_rsample(
+                hard_sample, tensor.distribution, self.temperature
             )
 
             hard_cost = cost_node
@@ -333,6 +310,41 @@ class RELAX(MonteCarloMethod):
 
     def adds_loss(self, tensor: StochasticTensor, cost_node: CostTensor) -> bool:
         return True
+
+
+class REBARMC(MonteCarlo):
+    def __init__(self, plate_name: str, n_samples: int, temperature):
+        super().__init__(plate_name, n_samples)
+        self.temperature = temperature
+
+    def mc_sample(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        amt_samples: int,
+    ) -> torch.Tensor:
+        relaxed_sample = rsample_gumbel(
+            distr, amt_samples, self.temperature, straight_through=False
+        )
+        # TODO: For rebar, what if sample from a sequence, and amt_samples is 1? Then three are sampled (for each one, also hard_sample and cond_sample.)
+        #    That'd still blow up... But I guess it's required?
+        # In REBAR, the objective function is evaluated for the Gumbel sample, the conditional Gumbel sample \tilde{z} and the argmax of the Gumbel sample.
+        hard_sample = discretize(relaxed_sample, distr)
+        cond_sample = conditional_gumbel_rsample(hard_sample, distr, self.temperature)
+
+        # return (H(z), z, z|H(z)
+        return torch.cat([hard_sample, relaxed_sample, cond_sample], 0)
+
+    def plate_weighting(
+        self, tensor: storch.StochasticTensor, plate: storch.Plate
+    ) -> Optional[storch.Tensor]:
+        # if REBAR: only weight over the true samples, put the relaxed samples to weight 0. This also makes sure
+        # that they will not be backpropagated through in the cost backwards pass
+        n = int(tensor.n / 3)
+        weighting = tensor.new_zeros((tensor.n,))
+        weighting[:n] = tensor.new_tensor(1.0 / n)
+        return weighting
 
 
 class REBAR(RELAX):

--- a/storch/method/unordered.py
+++ b/storch/method/unordered.py
@@ -1,14 +1,11 @@
 from typing import Optional
 
-import torch
 import storch
-from storch.method.sampling import (
-    SampleWithoutReplacementMethod,
-    log1mexp,
-)
+from storch.method.method import Method
+from storch.sampling import UnorderedSet
 
 
-class UnorderedSetEstimator(SampleWithoutReplacementMethod):
+class UnorderedSetEstimator(Method):
     """
     Implements the Unordered Set REINFORCE Estimator with baseline from https://openreview.net/forum?id=rklEj2EFvB
     (Wouter Kool et al, ICLR 2020)
@@ -41,95 +38,13 @@ class UnorderedSetEstimator(SampleWithoutReplacementMethod):
         :param a: Hyperparameter for numerical stable computation of the leave-one-out ratio. The default is recommended
         in https://openreview.net/forum?id=rklEj2EFvB, but could be tuned if NaNs pop up.
         """
-        super().__init__(plate_name, k)
+        super().__init__(
+            plate_name,
+            UnorderedSet(
+                plate_name, k, use_baseline, exact_integration, num_int_points, a
+            ),
+        )
         self.use_baseline = use_baseline
-        self.exact_integration = exact_integration
-        self.num_int_points = num_int_points
-        self.a = a
-
-    def plate_weighting(
-        self, tensor: storch.StochasticTensor, plate: storch.Plate
-    ) -> Optional[storch.Tensor]:
-        # plates_w_k is a sequence of plates of which one is the input ancestral plate
-
-        # Computes p(s) * R(S^k, s), or the probability of the sample times the leave-one-out ratio.
-        # For details, see https://openreview.net/pdf?id=rklEj2EFvB
-        # Code based on https://github.com/wouterkool/estimating-gradients-without-replacement/blob/master/bernoulli/gumbel.py
-        log_probs = plate.log_probs.detach()
-
-        # Compute integration points for the trapezoid rule: v should range from 0 to 1, where both v=0 and v=1 give a value of 0.
-        # As the computation happens in log-space, take the logarithm of the result.
-        # N
-        v = (
-            torch.arange(1, self.num_int_points, out=log_probs._tensor.new())
-            / self.num_int_points
-        )
-        log_v = v.log()
-
-        # Compute log(1-v^{exp(log_probs+a)}) in a numerically stable way in log-space
-        # Uses the gumbel_log_survival function from
-        # https://github.com/wouterkool/estimating-gradients-without-replacement/blob/master/bernoulli/gumbel.py
-        # plates_w_k x N
-        g_bound = (
-            log_probs[..., None]
-            + self.a
-            + torch.log(-log_v)[log_probs.plate_dims * (None,) + (slice(None),)]
-        )
-
-        # Gumbel log survival: log P(g > g_bound) = log(1 - exp(-exp(-g_bound))) for standard gumbel g
-        # If g_bound >= 10, use the series expansion for stability with error O((e^-10)^6) (=8.7E-27)
-        # See https://www.wolframalpha.com/input/?i=log%281+-+exp%28-y%29%29
-        y = torch.exp(g_bound)
-        # plates_w_k x N
-        terms = torch.where(
-            g_bound >= 10, -g_bound - y / 2 + y ** 2 / 24 - y ** 4 / 2880, log1mexp(y)
-        )
-
-        # Compute integrands (without subtracting the special value s)
-        # plates x N
-        sum_of_terms = storch.sum(terms, plate)
-        phi_S = storch.logsumexp(log_probs, plate)
-        phi_D_min_S = log1mexp(phi_S)
-
-        # plates x N
-        integrand = (
-            sum_of_terms
-            + torch.expm1(self.a + phi_D_min_S)[..., None]
-            * log_v[phi_D_min_S.plate_dims * (None,) + (slice(None),)]
-        )
-
-        # Subtract one term the for element that is left out in R
-        # Automatically unsqueezes correctly using plate dimensions
-        # plates_w_k x N
-        integrand_without_s = integrand - terms
-
-        # plates
-        log_p_S = integrand.logsumexp(dim=-1)
-        # plates_w_k
-        log_p_S_without_s = integrand_without_s.logsumexp(dim=-1)
-
-        # plates_w_k
-        log_leave_one_out = log_p_S_without_s - log_p_S
-
-        if self.use_baseline:
-            # Compute the integrands for the 2nd order leave one out ratio.
-            # Make sure to properly choose the indices: We shouldn't subtract the same term twice on the diagonals.
-            # k x k
-            skip_diag = storch.Tensor(
-                1 - torch.eye(plate.n, out=log_probs._tensor.new()), [], [plate]
-            )
-            # plates_w_k x k x N
-            integrand_without_ss = (
-                integrand_without_s[..., None, :]
-                - terms[..., None, :] * skip_diag[..., None]
-            )
-            # plates_w_k x k
-            log_p_S_without_ss = integrand_without_ss.logsumexp(dim=-1)
-
-            plate.log_snd_leave_one_out = log_p_S_without_ss - log_p_S_without_s
-
-        # Return the unordered set estimator weighting
-        return (log_leave_one_out + log_probs).exp().detach()
 
     def adds_loss(
         self, tensor: storch.StochasticTensor, cost_node: storch.CostTensor

--- a/storch/sampling/__init__.py
+++ b/storch/sampling/__init__.py
@@ -1,0 +1,7 @@
+from storch.sampling.method import (
+    SamplingMethod,
+    MonteCarlo,
+)
+from storch.sampling.expect import Enumerate
+from storch.sampling.swor import SampleWithoutReplacement
+from storch.sampling.unordered_set import UnorderedSet

--- a/storch/sampling/expect.py
+++ b/storch/sampling/expect.py
@@ -1,0 +1,87 @@
+from typing import Optional
+
+from storch.sampling import SamplingMethod
+from torch.distributions import Distribution
+import storch
+import torch
+from storch import Plate
+import itertools
+
+
+class Enumerate(SamplingMethod):
+    def __init__(self, plate_name: str, budget=10000):
+        super().__init__(plate_name)
+        self.budget = budget
+
+    def sample(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        requires_grad: bool,
+    ) -> (storch.StochasticTensor, Plate):
+        # TODO: Currently very inefficient as it isn't batched
+        # TODO: What if the expectation has a parent
+        if not distr.has_enumerate_support:
+            raise ValueError(
+                "Can only calculate the expected value for distributions with enumerable support."
+            )
+        support: torch.Tensor = distr.enumerate_support(expand=True)
+        support_non_expanded: torch.Tensor = distr.enumerate_support(expand=False)
+        expect_size = support.shape[0]
+
+        batch_len = len(plates)
+        sizes = support.shape[
+            batch_len + 1 : len(support.shape) - len(distr.event_shape)
+        ]
+        amt_samples_used = expect_size
+        cross_products = 1 if not sizes else None
+        for dim in sizes:
+            amt_samples_used = amt_samples_used ** dim
+            if not cross_products:
+                cross_products = dim
+            else:
+                cross_products = cross_products ** dim
+
+        if amt_samples_used > self.budget:
+            raise ValueError(
+                "Computing the expectation on this distribution would exceed the computation budget."
+            )
+
+        enumerate_tensor = support.new_zeros(
+            [amt_samples_used] + list(support.shape[1:])
+        )
+        support_non_expanded = support_non_expanded.squeeze().unsqueeze(1)
+        for i, t in enumerate(
+            itertools.product(support_non_expanded, repeat=cross_products)
+        ):
+            enumerate_tensor[i] = torch.cat(t, dim=0)
+
+        enumerate_tensor = enumerate_tensor.detach()
+
+        plate_size = enumerate_tensor.shape[0]
+
+        plate = Plate(self.plate_name, plate_size, plates.copy())
+        plates.insert(0, plate)
+
+        s_tensor = storch.StochasticTensor(
+            enumerate_tensor,
+            parents,
+            plates,
+            self.plate_name,
+            plate_size,
+            distr,
+            requires_grad,
+        )
+        return s_tensor, plate
+
+    def plate_weighting(
+        self, tensor: storch.StochasticTensor, plate: Plate
+    ) -> Optional[storch.Tensor]:
+        # Weight by the probability of each possible event
+        log_probs = tensor.distribution.log_prob(tensor)
+        if log_probs.plate_dims < len(log_probs.shape):
+            log_probs = log_probs.sum(
+                dim=list(range(tensor.plate_dims, len(log_probs.shape)))
+            )
+        return log_probs.exp()

--- a/storch/sampling/method.py
+++ b/storch/sampling/method.py
@@ -103,9 +103,9 @@ class MonteCarlo(SamplingMethod):
         requires_grad: bool,
     ) -> (storch.StochasticTensor, Plate):
         plate = None
-        for plate in plates:
-            if plate.name == self.plate_name:
-                plate = plate
+        for _plate in plates:
+            if _plate.name == self.plate_name:
+                plate = _plate
                 break
         n_samples = 1 if plate else self.n_samples
         with storch.ignore_wrapping():

--- a/storch/sampling/method.py
+++ b/storch/sampling/method.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+from typing import Optional, Callable, List
+
+import torch
+from torch.distributions import Distribution
+from abc import ABC, abstractmethod
+import storch
+from storch import Plate
+
+
+class SamplingMethod(ABC, torch.nn.Module):
+    def __init__(self, plate_name: str):
+        super().__init__()
+        self.reset()
+        self.plate_name = plate_name
+
+    def reset(self):
+        pass
+
+    def forward(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        requires_grad: bool,
+    ) -> (storch.StochasticTensor, Plate):
+        return self.sample(distr, parents, plates, requires_grad)
+
+    @abstractmethod
+    def sample(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        requires_grad: bool,
+    ) -> (storch.StochasticTensor, Plate):
+        pass
+
+    def plate_weighting(
+        self, tensor: storch.StochasticTensor, plate: Plate
+    ) -> Optional[storch.Tensor]:
+        """
+        Weight by the size of the sample. Overload this if your gradient estimation uses some kind of weighting
+        of the different events, like importance sampling or computing the expectation.
+        If None is returned, it is assumed the samples are iid monte carlo samples.
+        """
+        return None
+
+    def update_parameters(
+        self,
+        result_triples: [(storch.StochasticTensor, storch.CostTensor, torch.Tensor)],
+    ):
+        pass
+
+    def mc_sample(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        amt_samples: int,
+    ) -> torch.Tensor:
+        return distr.sample((self.n_samples,))
+
+    def set_mc_sample(
+        self,
+        new_sample_func: Callable[
+            [Distribution, [storch.Tensor], [Plate], int], torch.Tensor
+        ],
+    ) -> SamplingMethod:
+        """
+        Override storch.Method specific sampling functions.
+        This is called when initializing a storch.Method that has slightly different MC sampling semantics
+        (for example, reparameterization instead of normal sampling).
+        This allows for compatibility of different `storch.Method`'s with different `storch.sampling.Method`'s.
+        """
+        self.mc_sample = new_sample_func
+        return self
+
+    def on_plate_already_present(self, plate: Plate):
+        raise ValueError(
+            "Cannot create stochastic tensor with name "
+            + plate.name
+            + ". A parent sample has already used this name. Use a different name for this sample."
+        )
+
+
+class MonteCarlo(SamplingMethod):
+    """
+    Monte Carlo sampling methods use simple sampling methods that take n independent samples.
+    Unlike complex ancestral sampling methods such as SampleWithoutReplacementMethod, the sampling behaviour is not dependent
+    on earlier samples in the stochastic computation graph (but the distributions are!).
+    """
+
+    def __init__(self, plate_name: str, n_samples: int = 1):
+        super().__init__(plate_name)
+        self.n_samples = n_samples
+
+    def sample(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [Plate],
+        requires_grad: bool,
+    ) -> (storch.StochasticTensor, Plate):
+        with storch.ignore_wrapping():
+            # TODO: this is changed in the new version...
+            tensor = self.mc_sample(distr, parents, plates, self.n_samples)
+        plate_size = tensor.shape[0]
+        if tensor.shape[0] == 1:
+            tensor = tensor.squeeze(0)
+
+        plate = Plate(self.plate_name, plate_size, plates.copy())
+        plates.insert(0, plate)
+
+        if isinstance(tensor, storch.Tensor):
+            tensor = tensor._tensor
+
+        s_tensor = storch.StochasticTensor(
+            tensor, parents, plates, self.plate_name, plate_size, distr, requires_grad,
+        )
+        return s_tensor, plate

--- a/storch/sampling/method.py
+++ b/storch/sampling/method.py
@@ -102,15 +102,21 @@ class MonteCarlo(SamplingMethod):
         plates: [Plate],
         requires_grad: bool,
     ) -> (storch.StochasticTensor, Plate):
+        plate = None
+        for plate in plates:
+            if plate.name == self.plate_name:
+                plate = plate
+                break
+        n_samples = 1 if plate else self.n_samples
         with storch.ignore_wrapping():
-            # TODO: this is changed in the new version...
-            tensor = self.mc_sample(distr, parents, plates, self.n_samples)
+            tensor = self.mc_sample(distr, parents, plates, n_samples)
         plate_size = tensor.shape[0]
         if tensor.shape[0] == 1:
             tensor = tensor.squeeze(0)
 
-        plate = Plate(self.plate_name, plate_size, plates.copy())
-        plates.insert(0, plate)
+        if not plate:
+            plate = Plate(self.plate_name, plate_size, plates.copy())
+            plates.insert(0, plate)
 
         if isinstance(tensor, storch.Tensor):
             tensor = tensor._tensor

--- a/storch/sampling/seq.py
+++ b/storch/sampling/seq.py
@@ -399,7 +399,6 @@ class SequenceDecoding(SamplingMethod):
 
 
 class IterDecoding(SequenceDecoding):
-    @abstractmethod
     def decode(
         self,
         d_log_probs: storch.Tensor,

--- a/storch/sampling/seq.py
+++ b/storch/sampling/seq.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import itertools
+from abc import abstractmethod
+from typing import Union, List, Optional
+
+from storch.sampling.method import SamplingMethod
+from torch.distributions import Distribution
+import storch
+import torch
+
+
+class AncestralPlate(storch.Plate):
+    def __init__(
+        self,
+        name: str,
+        n: int,
+        parents: List[storch.Plate],
+        variable_index: int,
+        parent_plate: AncestralPlate,
+        selected_samples: storch.Tensor,
+        log_probs: storch.Tensor,
+        weight: Optional[storch.Tensor] = None,
+    ):
+        super().__init__(name, n, parents, weight)
+        assert (not parent_plate and variable_index == 0) or (
+            parent_plate.n <= self.n and parent_plate.variable_index < variable_index
+        )
+        self.parent_plate = parent_plate
+        self.selected_samples = selected_samples
+        self.log_probs = storch.Tensor(
+            log_probs._tensor, [log_probs], log_probs.plates + [self]
+        )
+        self.variable_index = variable_index
+        self._in_recursion = False
+        self._override_equality = False
+
+    def __eq__(self, other):
+        if self._override_equality:
+            return other.name == self.name
+        return (
+            super().__eq__(other)
+            and isinstance(other, AncestralPlate)
+            and self.variable_index == other.variable_index
+        )
+
+    def __repr__(self):
+        return (
+            "(Ancestral, " + self.variable_index.__repr__() + super().__repr__() + ")"
+        )
+
+    def on_collecting_args(self, plates: [storch.Plate]) -> bool:
+        """
+        Filter the collected plates to only keep the AncestralPlates (with the same name) that has the highest variable index.
+        :param plates:
+        :return:
+        """
+        if self._in_recursion:
+            self._override_equality = True
+        for plate in plates:
+            if plate.name == self.name:
+                if not isinstance(plate, AncestralPlate):
+                    raise ValueError(
+                        "Received a plate with name "
+                        + plate.name
+                        + " that is not also an AncestralPlate."
+                    )
+                if plate.variable_index > self.variable_index:
+                    # Only keep ancestral plates with the highest variable index
+                    return False
+        return True
+
+    def on_unwrap_tensor(self, tensor: storch.Tensor) -> storch.Tensor:
+        """
+        Gets called whenever the given tensor is being unwrapped and unsqueezed for batch use.
+        This method should not be called on tensors whose variable index is higher than this plates.
+        :param tensor: The input tensor that is being unwrapped
+        :return: The tensor that will be unwrapped and unsqueezed in the future. Can be a modification of the input tensor.
+        """
+        if self._in_recursion:
+            # Required when calling storch.gather in this method. It will call on_unwrap_tensor again.
+            return tensor
+        for i, plate in enumerate(tensor.multi_dim_plates()):
+            if plate.name != self.name:
+                continue
+            assert isinstance(plate, AncestralPlate)
+            if plate.variable_index == self.variable_index:
+                return tensor
+            # This is true by the filtering at on_collecting_args
+            assert plate.variable_index < self.variable_index
+
+            parent_plates = []
+            current_plate = self
+
+            # Collect the list of plates from the tensors variable index to this plates variable index
+            while current_plate.variable_index != plate.variable_index:
+                parent_plates.append(current_plate)
+                current_plate = current_plate.parent_plate
+            assert current_plate == plate
+
+            # Go over all parent plates and gather their respective choices.
+            for parent_plate in reversed(parent_plates):
+                self._in_recursion = True
+                expanded_selected_samples = expand_with_ignore_as(
+                    parent_plate.selected_samples, tensor, self.name
+                )
+                self._override_equality = False
+                # Gather what samples of the tensor are chosen by this plate (parent_plate)
+                tensor = storch.gather(
+                    tensor, parent_plate.name, expanded_selected_samples
+                )
+                self._in_recursion = False
+                self._override_equality = False
+            break
+        return tensor
+
+
+class SequenceDecoding(SamplingMethod):
+    """
+    Methods for generating sequences of discrete random variables.
+    Examples: Simple ancestral sampling with replacement, beam search, Stochastic beam search (sampling without replacement)
+    """
+
+    EPS = 1e-8
+
+    def __init__(self, plate_name: str, k: int):
+        super().__init__(plate_name)
+        self.k = k
+        self.reset()
+
+    def reset(self):
+        super().reset()
+        # Cumulative log probabilities of the samples
+        self.joint_log_probs = None
+        # Chosen parent samples at the previous sample step
+        self.parent_indexing = None
+        # The index of the currently sampled variable
+        self.variable_index = 0
+        # The previously created plates
+        self.last_plate = None
+
+    def sample(
+        self,
+        distr: Distribution,
+        parents: [storch.Tensor],
+        plates: [storch.Plate],
+        requires_grad: bool,
+    ) -> (torch.Tensor, storch.Plate):
+
+        """
+        Sample from the distribution given the sequence so far.
+        :param distribution: The distribution to sample from
+        :return:
+        """
+
+        # This code has three parts.
+        # The first prepares all necessary tensors to make sure they can be easily indexed.
+        # This part is quite long as there are many cases.
+        # 1) There have not been any variables sampled so far.
+        # 2) There have been variables sampled, but their results are NOT used to compute the input distribution.
+        #    in other words, the variable to sample is independent of the other sampled variables. However,
+        #    we should still keep track of the other sampled variables to make sure that it still samples without
+        #    replacement properly. In this case, the ancestral plate is not in the plates attribute.
+        #    We also have to make sure that we know in the future what samples are chosen for the _other_ samples.
+        # 3) There have been parents sampled, and this variable is dependent on at least some of them.
+        #    The plates list then contains the ancestral plate. We need to make sure we compute the joint log probs
+        #    for the conditional samples (ie, based on the different sampled variables in the ancestral dimension).
+        # The second part is a loop over all options for the event dimensions. This samples these conditionally
+        # independent samples in sequence. It samples indexes, not events.
+        # The third part after the loop uses the sampled indexes and matches it to the events to be used.
+
+        # LEGEND FOR SHAPE COMMENTS
+        # =========================
+        # To make this code generalize to every bayesian network, complicated shape management is necessary.
+        # The following are references to the shapes that are used within the method
+        #
+        # distr_plates: refers to the plates on the parameters of the distribution. Does *not* include
+        #  the k? ancestral plate (possibly empty)
+        # orig_distr_plates: refers to the plates on the parameters of the distribution, and *can* include
+        #  the k? ancestral plate (possibly empty)
+        # prev_plates: refers to the plates of the previous sampled variable in this swr sample (possibly empty)
+        # plates: refers to all plates except this ancestral plate, of which there are amt_plates.
+        #  It is composed of distr_plate x (ancstr_plates - distr_plates)
+        # events: refers to the conditionally independent dimensions of the distribution (the distributions batch shape minus the plates)
+        # k: refers to self.k
+        # k?: refers to an optional plate dimension of this ancestral plate. It either doesn't exist, or is the sample
+        #  dimension. If it exists, this means this sample is conditionally dependent on ancestors.
+        # |D_yv|: refers to the *size* of the domain
+        # amt_samples: refers to the current amount of sampled sequences. amt_samples <= k, but it can be lower if there
+        #  are not enough events to sample from (eg |D_yv| < k)
+        # event_shape: refers to the *shape* of the domain elements
+        #  (can be 0, eg Categorical, or equal to |D_yv| for OneHotCategorical)
+
+        orig_distr_plates = []
+        for plate in plates:
+            if plate.n > 1:
+                orig_distr_plates.append(plate)
+        # Sample using stochastic beam search
+        # plates? x k x events x
+        ancestral_distrplate_index = -1
+        is_conditional_sample = False
+        distr_plates = orig_distr_plates
+        for i, plate in enumerate(orig_distr_plates):
+            if plate.name == self.plate_name:
+                ancestral_distrplate_index = i
+                is_conditional_sample = True
+                distr_plates = orig_distr_plates.copy()
+                distr_plates.remove(plate)
+                break
+
+        # TODO: This doesn't properly combine two ancestral plates with the same name but different variable index
+        #  (they should merge).
+        all_plates = distr_plates.copy()
+        prev_plate_shape = ()
+        if self.variable_index > 0:
+            # Previous variables have been sampled. add the prev_plates to all_plates
+            for plate in self.joint_log_probs.plates:
+                if plate not in distr_plates:
+                    all_plates.append(plate)
+                    prev_plate_shape = prev_plate_shape + (plate.n,)
+
+        amt_plates = len(all_plates)
+        amt_distr_plates = len(distr_plates)
+        amt_orig_distr_plates = len(orig_distr_plates)
+        if not distr.has_enumerate_support:
+            raise ValueError("Can only decode distributions with enumerable support.")
+
+        # |D_yv| x distr_plate[0] x ... x k? x ... x distr_plate[n-1] x events x event_shape
+        support = distr.enumerate_support(expand=True)
+
+        if ancestral_distrplate_index != -1:
+            # Reduce ancestral dimension in the support. As the dimension is just an expanded version, this should
+            # not change the underlying data.
+            # |D_yv| x distr_plates x events x event_shape
+            support = support[
+                (..., 0)
+                + (slice(None),) * (len(support.shape) - ancestral_distrplate_index - 2)
+            ]
+
+        # Equal to event_shape
+        element_shape = distr.event_shape
+        support_permutation = (
+            tuple(range(1, amt_distr_plates + 1))
+            + (0,)
+            + tuple(range(amt_distr_plates + 1, len(support.shape)))
+        )
+        # distr_plates x |D_yv| x events x event_shape
+        support = support.permute(support_permutation)
+
+        if amt_plates != amt_distr_plates:
+            # If previous samples had a plate that are not in the distribution plates, add these to the support.
+            support = support[
+                (slice(None),) * amt_distr_plates
+                + (None,) * (amt_plates - amt_distr_plates)
+            ]
+            # plates x |D_yv| x events x event_shape
+            support = support.expand(
+                (-1,) * amt_distr_plates
+                + prev_plate_shape
+                + (-1,) * (len(support.shape) - amt_distr_plates - 1)
+            )
+        support = storch.Tensor(support, [], all_plates)
+
+        # Equal to events: Shape for the different conditional independent dimensions
+        event_shape = support.shape[
+            amt_plates + 1 : -len(element_shape) if len(element_shape) > 0 else None
+        ]
+
+        with storch.ignore_wrapping():
+            # |D_yv| x (|distr_plates| + |k?| + |event_dims|) * (1,) x |D_yv|
+            support_non_expanded: torch.Tensor = distr.enumerate_support(expand=False)
+            # Compute the log-probability of the different events
+            # |D_yv| x distr_plate[0] x ... k? ... x distr_plate[n-1] x events
+            d_log_probs = distr.log_prob(support_non_expanded)
+
+            # Note: Use amt_orig_distr_plates here because it might include k? dimension. amt_distr_plates filters this one.
+            # distr_plate[0] x ... k? ... x distr_plate[n-1] x |D_yv| x events
+            d_log_probs = storch.Tensor(
+                d_log_probs.permute(
+                    tuple(range(1, amt_orig_distr_plates + 1))
+                    + (0,)
+                    + tuple(
+                        range(
+                            amt_orig_distr_plates + 1,
+                            amt_orig_distr_plates + 1 + len(event_shape),
+                        )
+                    )
+                ),
+                [],
+                orig_distr_plates,
+            )
+        if is_conditional_sample:
+            # Gather the correct log probabilities
+            # distr_plate[0] x ... k ... x distr_plate[n-1] x |D_yv| x events
+            # TODO: Move this down below to the other scary TODO
+            d_log_probs = self.last_plate.on_unwrap_tensor(d_log_probs)
+            # Permute the dimensions of d_log_probs st the k dimension is after the plates.
+            for i, plate in enumerate(d_log_probs.multi_dim_plates()):
+                if plate.name == self.plate_name:
+                    # k is present in the plates
+                    d_log_probs.plates.remove(plate)
+                    # distr_plates x k x |D_yv| x events
+                    d_log_probs._tensor = d_log_probs._tensor.permute(
+                        tuple(range(0, i))
+                        + tuple(range(i + 1, amt_orig_distr_plates))
+                        + (i,)
+                        + tuple(range(amt_orig_distr_plates, len(d_log_probs.shape)))
+                    )
+                    break
+
+        # Seperate classes into AbstractBeam class and this one, where this one doesn't compute all prerequisites.
+        # AbstractBeam is for BeamSearch and SWOR (stochastic beam)
+
+        # Do the decoding step given the prepared tensors
+        samples, self.joint_log_probs, self.parent_indexing = self.decode(
+            d_log_probs,
+            support,
+            self.joint_log_probs,
+            is_conditional_sample,
+            amt_plates,
+            event_shape,
+            element_shape,
+        )
+
+        k_index = 0
+        if isinstance(samples, storch.Tensor):
+            k_index = samples.plate_dims
+            plates = samples.plates
+            samples = samples._tensor
+
+        plate_size = samples.shape[k_index]
+
+        # Remove the ancestral plate, if it already happens to be in
+        to_remove = None
+        for plate in plates:
+            if plate.name == self.plate_name:
+                to_remove = plate
+                break
+        if to_remove:
+            plates.remove(to_remove)
+
+        # Create the newly updated plate
+        self.last_plate = self.create_plate(plate_size, plates.copy())
+        plates.append(self.last_plate)
+
+        if self.parent_indexing is not None:
+            self.parent_indexing.plates.append(self.last_plate)
+
+        # Construct the stochastic tensor
+        s_tensor = storch.StochasticTensor(
+            samples,
+            parents,
+            plates,
+            self.plate_name,
+            plate_size,
+            distr,
+            requires_grad or self.joint_log_probs.requires_grad,
+        )
+        # Increase variable index
+        self.variable_index += 1
+        return s_tensor, self.last_plate
+
+    @abstractmethod
+    def decode(
+        self,
+        d_log_probs: storch.Tensor,
+        support: storch.Tensor,
+        joint_log_probs: Optional[storch.Tensor],
+        is_conditional_sample: bool,
+        amt_plates: int,
+        event_shape: torch.Size,
+        element_shape: torch.Size,
+    ) -> (storch.Tensor, storch.Tensor, storch.Tensor):
+        """
+        Decode given the input arguments
+        :param d_log_probs: Log probability given by the distribution. distr_plates x k? x |D_yv| x events
+        :param support: The support of this distribution. plates x |D_yv| x events x event_shape
+        :param joint_log_probs: The log probabilities of the samples so far. prev_plates x amt_samples
+        :param is_conditional_sample: True if a parent has already been sampled. This means the plates are more complex!
+        :param amt_plates: The total amount of plates in both the distribution and the previously sampled variables
+        :param event_shape: The shape of the conditionally independent events
+        :param element_shape: The shape of a domain element. (|D_yv|,) for `torch.distributions.OneHotCategorical`, otherwise (,).
+        :return: 3-tuple of `storch.Tensor`. 1: The sampled value. 2: The new joint log probabilities of the samples.
+        3: How the samples index the parent samples. Can just be a range if there is no choosing happening.
+        """
+        pass
+
+    def create_plate(self, plate_size: int, plates: [storch.Plate]) -> AncestralPlate:
+        return AncestralPlate(
+            self.plate_name,
+            plate_size,
+            plates.copy(),
+            self.variable_index,
+            self.last_plate,
+            self.parent_indexing,
+            self.joint_log_probs,
+            None,
+        )
+
+
+def expand_with_ignore_as(
+    tensor, expand_as, ignore_dim: Union[str, int]
+) -> torch.Tensor:
+    """
+    Expands the tensor like expand_as, but ignores a single dimension.
+    Ie, if tensor is of size a x b,  expand_as of size d x a x c and dim=-1, then the return will be of size d x a x b.
+    It also automatically expands all plate dimensions correctly.
+    :param ignore_dim: Can be a string referring to the plate dimension
+    """
+    # diff = expand_as.ndim - tensor.ndim
+    def _expand_with_ignore(tensor, expand_as, dim: int):
+        new_dims = expand_as.ndim - tensor.ndim
+        # after_dims = tensor.ndim - dim
+        return tensor[(...,) + (None,) * new_dims].expand(
+            expand_as.shape[:dim]
+            + (-1,)
+            + (expand_as.shape[dim + 1 :] if dim != -1 else ())
+        )
+
+    if isinstance(ignore_dim, str):
+        return storch.deterministic(
+            _expand_with_ignore, expand_plates=True, dim=ignore_dim
+        )(tensor, expand_as)
+    return storch.deterministic(_expand_with_ignore, expand_plates=True)(
+        tensor, expand_as, ignore_dim
+    )

--- a/storch/sampling/swor.py
+++ b/storch/sampling/swor.py
@@ -29,7 +29,7 @@ class SampleWithoutReplacement(IterDecoding):
     def reset(self):
         super().reset()
         # Cumulative perturbed log probabilities of the samples
-        self.perturbed_log_probs = None
+        self.perturbed_log_probs: Optional[storch.Tensor] = None
 
     def decode_step(
         self,
@@ -43,7 +43,7 @@ class SampleWithoutReplacement(IterDecoding):
         amt_samples: int,
     ) -> (storch.Tensor, storch.Tensor, storch.Tensor):
         """
-        Decode given the input arguments for a specific event using stochastic beam search. 
+        Decode given the input arguments for a specific event using stochastic beam search.
         :param indices: Tuple of integers indexing the current event to sample.
         :param yv_log_probs:  Log probabilities of the different options for this event. distr_plates x k? x |D_yv|
         :param joint_log_probs: The log probabilities of the samples so far. None if `not is_conditional_sample`. prev_plates x amt_samples
@@ -141,9 +141,9 @@ class SampleWithoutReplacement(IterDecoding):
     def create_plate(self, plate_size: int, plates: [storch.Plate]) -> AncestralPlate:
         plate = super().create_plate(plate_size, plates)
         plate.perturb_log_probs = storch.Tensor(
-            self.perturb_log_probs._tensor,
-            [self.perturb_log_probs],
-            self.perturb_log_probs.plates + [plate],
+            self.perturbed_log_probs._tensor,
+            [self.perturbed_log_probs],
+            self.perturbed_log_probs.plates + [plate],
         )
         return plate
 

--- a/storch/sampling/swor.py
+++ b/storch/sampling/swor.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
-from typing import Optional, Union, List, Callable
+from typing import Optional, Union, List, Callable, Tuple
 
 import storch
 import torch
 from torch.distributions import Distribution, Gumbel
 import itertools
-from storch.sampling.seq import SequenceDecoding, AncestralPlate
+from storch.sampling.method import SamplingMethod
+from storch.sampling.seq import IterDecoding, AncestralPlate, right_expand_as
 
 
-class SampleWithoutReplacement(SequenceDecoding):
+class SampleWithoutReplacement(IterDecoding):
     """
     Sampling method for sampling without replacement from (sequences of) discrete distributions.
     Implements Stochastic Beam Search https://arxiv.org/abs/1903.06059 with the weighting as defined by
@@ -30,158 +31,112 @@ class SampleWithoutReplacement(SequenceDecoding):
         # Cumulative perturbed log probabilities of the samples
         self.perturbed_log_probs = None
 
-    def decode(
+    def decode_step(
         self,
-        d_log_probs: storch.Tensor,
-        support: storch.Tensor,
+        indices: Tuple[int],
+        yv_log_probs: storch.Tensor,
         joint_log_probs: Optional[storch.Tensor],
+        sampled_support_indices: Optional[storch.Tensor],
+        parent_indexing: Optional[storch.Tensor],
         is_conditional_sample: bool,
         amt_plates: int,
-        event_shape: torch.Size,
-        element_shape: torch.Size,
+        amt_samples: int,
     ) -> (storch.Tensor, storch.Tensor, storch.Tensor):
         """
-        Decode using stochastic beam search.
-        :param d_log_probs: Log probability given by the distribution. distr_plates x k? x |D_yv| x events
-        :param support: The support of this distribution. plates x |D_yv| x events x event_shape
-        :param joint_log_probs: The log probabilities of the samples so far. prev_plates x amt_samples
+        Decode given the input arguments for a specific event using stochastic beam search. 
+        :param indices: Tuple of integers indexing the current event to sample.
+        :param yv_log_probs:  Log probabilities of the different options for this event. distr_plates x k? x |D_yv|
+        :param joint_log_probs: The log probabilities of the samples so far. None if `not is_conditional_sample`. prev_plates x amt_samples
+        :param sampled_support_indices: Tensor of samples so far. None if this is the first set of indices. plates x k x events
+        :param parent_indexing: Tensor indexing the parent sample. None if `not is_conditional_sample`.
         :param is_conditional_sample: True if a parent has already been sampled. This means the plates are more complex!
         :param amt_plates: The total amount of plates in both the distribution and the previously sampled variables
-        :param event_shape: The shape of the conditionally independent events
-        :param element_shape: The shape of a domain element. (|D_yv|,) for `torch.distributions.OneHotCategorical`, otherwise (,).
-        :return: 3-tuple of `storch.Tensor`. 1: The sampled value. 2: The new joint log probabilities of the samples.
-        3: How the samples index the parent samples. Can just be a range if there is no choosing happening.
+        :param amt_samples: The amount of active samples.
+        :return: 3-tuple of `storch.Tensor`. 1: sampled_support_indices, with `:, indices` referring to the indices for the support.
+        2: The updated `joint_log_probs` of the samples.
+        3: The updated `parent_indexing`. How the samples index the parent samples. Can just return parent_indexing if nothing happens.
+        4: The amount of active samples after this step.
         """
-        ranges = []
-        for size in event_shape:
-            ranges.append(list(range(size)))
 
-        amt_samples = 0
-        parent_indexing = None
-        if joint_log_probs is not None:
-            # Initialize a tensor (self.parent_indexing) that keeps track of what samples link to previous choices of samples
-            # Note that joint_log_probs.shape[-1] is amt_samples, not k. It's possible that amt_samples < k!
-            amt_samples = joint_log_probs.shape[-1]
-            # plates x k
-            parent_indexing = support.new_zeros(
-                size=support.shape[:amt_plates] + (self.k,), dtype=torch.long
+        first_sample = False
+        if joint_log_probs is None:
+            # We also know that k? is not present, so distr_plates x |D_yv|
+            all_joint_log_probs = yv_log_probs
+            # First condition on max being 0:
+            self.perturbed_log_probs = 0.0
+            first_sample = True
+        elif is_conditional_sample:
+            # Make sure we are selecting the correct log-probabilities. As parents have been selected, this might change!
+            # plates x amt_samples x |D_yv|
+            yv_log_probs = yv_log_probs.gather(
+                dim=-2,
+                index=right_expand_as(
+                    # Use the parent_indexing to select the correct plate samples. Make sure to limit to amt_samples!
+                    parent_indexing[..., :amt_samples],
+                    yv_log_probs,
+                ),
+            )
+            # self.joint_log_probs: prev_plates x amt_samples
+            # plates x amt_samples x |D_yv|
+            all_joint_log_probs = joint_log_probs.unsqueeze(-1) + yv_log_probs
+        else:
+            # self.joint_log_probs: plates x amt_samples
+            # plates x amt_samples x |D_yv|
+            all_joint_log_probs = joint_log_probs.unsqueeze(
+                -1
+            ) + yv_log_probs.unsqueeze(-2)
+
+        # Sample plates x k? x |D_yv| conditional Gumbel variables
+        cond_G_yv = cond_gumbel_sample(all_joint_log_probs, self.perturbed_log_probs)
+        if first_sample:
+            # No parent has been sampled yet
+            # shape(cond_G_yv) is plates x |D_yv|
+            amt_samples = min(self.k, cond_G_yv.shape[-1])
+            # Compute top k over the conditional perturbed log probs
+            # plates x amt_samples
+            self.perturbed_log_probs, arg_top = torch.topk(
+                cond_G_yv, amt_samples, dim=-1
+            )
+            # plates x amt_samples
+            joint_log_probs = all_joint_log_probs.gather(dim=-1, index=arg_top)
+            # Index for the selected samples. Uses slice(amt_samples) for the first index in case k > |D_yv|
+            # (:) * amt_plates + (indices for events) + amt_samples
+            indexing = (slice(None),) * amt_plates + (slice(0, amt_samples),) + indices
+            sampled_support_indices[indexing] = arg_top
+        else:
+            # plates x (k * |D_yv|) (k == prev_amt_samples, in this case)
+            cond_G_yv = cond_G_yv.reshape(cond_G_yv.shape[:-2] + (-1,))
+            # We can sample at most the amount of what we previous sampled, combined with every option in the current domain
+            # That is: prev_amt_samples * |D_yv|. But we also want to limit by k.
+            amt_samples = min(self.k, cond_G_yv.shape[-1])
+            # Take the top k over conditional perturbed log probs
+            # plates x amt_samples
+            self.perturbed_log_probs, arg_top = torch.topk(
+                cond_G_yv, amt_samples, dim=-1
+            )
+            # Gather corresponding joint log probabilities. First reshape like previous to plates x (k * |D_yv|).
+            joint_log_probs = all_joint_log_probs.reshape(cond_G_yv.shape).gather(
+                dim=-1, index=arg_top
             )
 
-            # probably can go wrong if plates are missing.
-            parent_indexing[..., :amt_samples] = left_expand_as(
-                torch.arange(amt_samples), parent_indexing
+            # |D_yv|
+            size_domain = yv_log_probs.shape[-1]
+
+            # Keep track of what parents were sampled for the arg top
+            # plates x amt_samples
+            chosen_parents = arg_top // size_domain
+            sampled_support_indices = sampled_support_indices.gather(
+                dim=amt_plates,
+                index=right_expand_as(chosen_parents, sampled_support_indices),
             )
-        # plates x k x events
-        sampled_support_indices = support.new_zeros(
-            size=support.shape[:amt_plates]  # plates
-            + (self.k,)
-            + support.shape[
-                amt_plates + 1 : -len(element_shape) if len(element_shape) > 0 else None
-            ],  # events
-            dtype=torch.long,
-        )
-        # Sample independent tensors in sequence
-        # Iterate over the different (conditionally) independent samples being taken (the events)
-        for indices in itertools.product(*ranges):
-            # Log probabilities of the different options for this sample step (event)
-            # distr_plates x k? x |D_yv|
-            yv_log_probs = d_log_probs[(...,) + indices]
-            first_sample = False
-            if joint_log_probs is None:
-                # We also know that k? is not present, so distr_plates x |D_yv|
-                all_joint_log_probs = yv_log_probs
-                # First condition on max being 0:
-                self.perturbed_log_probs = 0.0
-                first_sample = True
-            elif is_conditional_sample:
-                # Make sure we are selecting the correct log-probabilities. As parents have been selected, this might change!
-                # plates x amt_samples x |D_yv|
-                yv_log_probs = yv_log_probs.gather(
-                    dim=-2,
-                    index=right_expand_as(
-                        # Use the parent_indexing to select the correct plate samples. Make sure to limit to amt_samples!
-                        parent_indexing[..., :amt_samples],
-                        yv_log_probs,
-                    ),
-                )
-                # self.joint_log_probs: prev_plates x amt_samples
-                # plates x amt_samples x |D_yv|
-                all_joint_log_probs = joint_log_probs.unsqueeze(-1) + yv_log_probs
-            else:
-                # self.joint_log_probs: plates x amt_samples
-                # plates x amt_samples x |D_yv|
-                all_joint_log_probs = joint_log_probs.unsqueeze(
-                    -1
-                ) + yv_log_probs.unsqueeze(-2)
-
-            # Sample plates x k? x |D_yv| conditional Gumbel variables
-            cond_G_yv = cond_gumbel_sample(
-                all_joint_log_probs, self.perturbed_log_probs
-            )
-            if first_sample:
-                # No parent has been sampled yet
-                # shape(cond_G_yv) is plates x |D_yv|
-                amt_samples = min(self.k, cond_G_yv.shape[-1])
-                # Compute top k over the conditional perturbed log probs
-                # plates x amt_samples
-                self.perturbed_log_probs, arg_top = torch.topk(
-                    cond_G_yv, amt_samples, dim=-1
-                )
-                # plates x amt_samples
-                joint_log_probs = all_joint_log_probs.gather(dim=-1, index=arg_top)
-                # Index for the selected samples. Uses slice(amt_samples) for the first index in case k > |D_yv|
-                # (:) * amt_plates + (indices for events) + amt_samples
-                indexing = (
-                    (slice(None),) * amt_plates + (slice(0, amt_samples),) + indices
-                )
-                sampled_support_indices[indexing] = arg_top
-            else:
-                # plates x (k * |D_yv|) (k == prev_amt_samples, in this case)
-                cond_G_yv = cond_G_yv.reshape(cond_G_yv.shape[:-2] + (-1,))
-                # We can sample at most the amount of what we previous sampled, combined with every option in the current domain
-                # That is: prev_amt_samples * |D_yv|. But we also want to limit by k.
-                amt_samples = min(self.k, cond_G_yv.shape[-1])
-                # Take the top k over conditional perturbed log probs
-                # plates x amt_samples
-                self.perturbed_log_probs, arg_top = torch.topk(
-                    cond_G_yv, amt_samples, dim=-1
-                )
-                # Gather corresponding joint log probabilities. First reshape like previous to plates x (k * |D_yv|).
-                joint_log_probs = all_joint_log_probs.reshape(cond_G_yv.shape).gather(
-                    dim=-1, index=arg_top
-                )
-
-                # |D_yv|
-                size_domain = yv_log_probs.shape[-1]
-
-                # Keep track of what parents were sampled for the arg top
-                # plates x amt_samples
-                chosen_parents = arg_top // size_domain
-                sampled_support_indices = sampled_support_indices.gather(
-                    dim=amt_plates,
-                    index=right_expand_as(chosen_parents, sampled_support_indices),
-                )
-                if parent_indexing is not None:
-                    parent_indexing = parent_indexing.gather(
-                        dim=-1, index=chosen_parents
-                    )
-                # Index for the selected samples. Uses slice(amt_samples) for the first index in case k > |D_yv|
-                # plates x amt_samples
-                chosen_samples = arg_top.remainder(size_domain)
-                indexing = (
-                    (slice(None),) * amt_plates + (slice(0, amt_samples),) + indices
-                )
-                sampled_support_indices[indexing] = chosen_samples
-
-        # Finally, index the support using the sampled indices to get the sample!
-        if amt_samples < self.k:
-            # plates x amt_samples x events
-            sampled_support_indices = sampled_support_indices[
-                (...,) + (slice(amt_samples),) + (slice(None),) * len(ranges)
-            ]
-        expanded_indices = right_expand_as(sampled_support_indices, support)
-        sample = support.gather(dim=amt_plates, index=expanded_indices)
-        return sample, joint_log_probs, parent_indexing
+            if parent_indexing is not None:
+                parent_indexing = parent_indexing.gather(dim=-1, index=chosen_parents)
+            # Index for the selected samples. Uses slice(amt_samples) for the first index in case k > |D_yv|
+            # plates x amt_samples
+            chosen_samples = arg_top.remainder(size_domain)
+            indexing = (slice(None),) * amt_plates + (slice(0, amt_samples),) + indices
+            sampled_support_indices[indexing] = chosen_samples
+        return sampled_support_indices, joint_log_probs, parent_indexing, amt_samples
 
     def create_plate(self, plate_size: int, plates: [storch.Plate]) -> AncestralPlate:
         plate = super().create_plate(plate_size, plates)
@@ -256,16 +211,3 @@ def cond_gumbel_sample(all_joint_log_probs, perturbed_log_probs) -> torch.Tensor
     vi = T - G_yv + log1mexp(G_yv - Z.unsqueeze(-1))
     # plates (x k) x |D_yv|
     return T - vi.relu() - torch.nn.Softplus()(-vi.abs())
-
-
-@storch.deterministic(l_broadcast=False)
-def right_expand_as(tensor, expand_as):
-    diff = expand_as.ndim - tensor.ndim
-    return tensor[(...,) + (None,) * diff].expand(
-        (-1,) * tensor.ndim + expand_as.shape[tensor.ndim :]
-    )
-
-
-def left_expand_as(tensor, expand_as):
-    diff = expand_as.ndim - tensor.ndim
-    return tensor[(None,) * diff].expand(expand_as.shape[:diff] + (-1,) * tensor.ndim)

--- a/storch/sampling/swor.py
+++ b/storch/sampling/swor.py
@@ -5,12 +5,12 @@ import storch
 import torch
 from torch.distributions import Distribution, Gumbel
 import itertools
-from storch.sampling import SamplingMethod
+from storch.sampling.seq import SequenceDecoding, AncestralPlate
 
 
-class SampleWithoutReplacement(SamplingMethod):
+class SampleWithoutReplacement(SequenceDecoding):
     """
-    Base class for gradient estimation methods that sample without replacement from (sequences of) discrete distributions.
+    Sampling method for sampling without replacement from (sequences of) discrete distributions.
     Implements Stochastic Beam Search https://arxiv.org/abs/1903.06059 with the weighting as defined by
     REINFORCE without replacement https://openreview.net/forum?id=r1lgTGL5DE
     """
@@ -18,300 +18,68 @@ class SampleWithoutReplacement(SamplingMethod):
     EPS = 1e-8
 
     def __init__(self, plate_name: str, k: int, biased_iw: bool = False):
-
-        super().__init__(plate_name)
+        super().__init__(plate_name, k)
         if k < 2:
             raise ValueError(
                 "Can only sample with replacement for more than 1 samples."
             )
-        self.k = k
-        self.reset()
         self.biased_iw = biased_iw
 
     def reset(self):
-        # Cumulative log probabilities of the samples
-        self.joint_log_probs = None
+        super().reset()
         # Cumulative perturbed log probabilities of the samples
         self.perturbed_log_probs = None
-        # Chosen parent samples at the previous sample step
-        self.parent_indexing = None
-        # The index of the currently sampled variable
-        self.variable_index = 0
-        # The previously created plates
-        self.last_plate = None
 
-    def sample(
+    def decode(
         self,
-        distr: Distribution,
-        parents: [storch.Tensor],
-        plates: [storch.Plate],
-        requires_grad: bool,
-    ) -> (torch.Tensor, storch.Plate):
+        d_log_probs: storch.Tensor,
+        support: storch.Tensor,
+        joint_log_probs: Optional[storch.Tensor],
+        is_conditional_sample: bool,
+        amt_plates: int,
+        event_shape: torch.Size,
+        element_shape: torch.Size,
+    ) -> (storch.Tensor, storch.Tensor, storch.Tensor):
         """
-        Perform stochastic beam search given the log-probs and perturbed log probs so far.
-        Samples k values from this distribution so that all total configurations are unique.
-        :param distr torch.distribution.Distribution: The distribution to sample from. Must be enumerable
-        :param parents [storch.Tensor]: Parents of this stochastic node
-        :param plates [storch.Plate]:
-        :param requires_grad bool:
-        :return: Tensor and plate
+        Decode using stochastic beam search.
+        :param d_log_probs: Log probability given by the distribution. distr_plates x k? x |D_yv| x events
+        :param support: The support of this distribution. plates x |D_yv| x events x event_shape
+        :param joint_log_probs: The log probabilities of the samples so far. prev_plates x amt_samples
+        :param is_conditional_sample: True if a parent has already been sampled. This means the plates are more complex!
+        :param amt_plates: The total amount of plates in both the distribution and the previously sampled variables
+        :param event_shape: The shape of the conditionally independent events
+        :param element_shape: The shape of a domain element. (|D_yv|,) for `torch.distributions.OneHotCategorical`, otherwise (,).
+        :return: 3-tuple of `storch.Tensor`. 1: The sampled value. 2: The new joint log probabilities of the samples.
+        3: How the samples index the parent samples. Can just be a range if there is no choosing happening.
         """
-
-        multi_dim_plates = []
-        for plate in plates:
-            if plate.n > 1:
-                multi_dim_plates.append(plate)
-        # Sample using stochastic beam search
-        # plates? x k x events x
-        samples = self.stochastic_beam_search(distr, multi_dim_plates)
-
-        k_index = 0
-        if isinstance(samples, storch.Tensor):
-            k_index = samples.plate_dims
-            plates = samples.plates
-            samples = samples._tensor
-
-        plate_size = samples.shape[k_index]
-
-        # Remove the ancestral plate, if it already happens to be in
-        to_remove = None
-        for plate in plates:
-            if plate.name == self.plate_name:
-                to_remove = plate
-                break
-        if to_remove:
-            plates.remove(to_remove)
-
-        # Create the newly updated plate
-        self.last_plate = AncestralPlate(
-            self.plate_name,
-            plate_size,
-            plates.copy(),
-            self.variable_index,
-            self.last_plate,
-            self.parent_indexing,
-            self.joint_log_probs,
-            self.perturbed_log_probs,
-            None,
-        )
-        plates.append(self.last_plate)
-
-        if self.parent_indexing is not None:
-            self.parent_indexing.plates.append(self.last_plate)
-
-        # Construct the stochastic tensor
-        s_tensor = storch.StochasticTensor(
-            samples,
-            parents,
-            plates,
-            self.plate_name,
-            plate_size,
-            distr,
-            requires_grad or self.joint_log_probs.requires_grad,
-        )
-        # Increase variable index
-        self.variable_index += 1
-        return s_tensor, self.last_plate
-
-    def stochastic_beam_search(
-        self, distribution: Distribution, orig_distr_plates: [storch.Plate],
-    ) -> torch.Tensor:
-        """
-        Implements Ancestral Gumbel-Top-k sampling with m=k, known as Stochastic Beam Search: http://jmlr.org/papers/v21/19-985.html.
-        Sample k events from the distribution so that the total generated sample throughout all sample steps
-        is a sample without replacement. This method supports sampling without replacement on  arbitrary stochastic
-        computation graphs.
-        :param distribution: The distribution to sample from
-        :return:
-        """
-
-        # This code has three parts.
-        # The first prepares all necessary tensors to make sure they can be easily indexed.
-        # This part is quite long as there are many cases.
-        # 1) There have not been any variables sampled so far.
-        # 2) There have been variables sampled, but their results are NOT used to compute the input distribution.
-        #    in other words, the variable to sample is independent of the other sampled variables. However,
-        #    we should still keep track of the other sampled variables to make sure that it still samples without
-        #    replacement properly. In this case, the ancestral plate is not in the plates attribute.
-        #    We also have to make sure that we know in the future what samples are chosen for the _other_ samples.
-        # 3) There have been parents sampled, and this variable is dependent on at least some of them.
-        #    The plates list then contains the ancestral plate. We need to make sure we compute the joint log probs
-        #    for the conditional samples (ie, based on the different sampled variables in the ancestral dimension).
-        # The second part is a loop over all options for the event dimensions. This samples these conditionally
-        # independent samples in sequence. It samples indexes, not events.
-        # The third part after the loop uses the sampled indexes and matches it to the events to be used.
-
-        # LEGEND FOR SHAPE COMMENTS
-        # =========================
-        # To make this code generalize to every bayesian network, complicated shape management is necessary.
-        # The following are references to the shapes that are used within the method
-        #
-        # distr_plates: refers to the plates on the parameters of the distribution. Does *not* include
-        #  the k? ancestral plate (possibly empty)
-        # orig_distr_plates: refers to the plates on the parameters of the distribution, and *can* include
-        #  the k? ancestral plate (possibly empty)
-        # prev_plates: refers to the plates of the previous sampled variable in this swr sample (possibly empty)
-        # plates: refers to all plates except this ancestral plate, of which there are amt_plates.
-        #  It is composed of distr_plate x (ancstr_plates - distr_plates)
-        # events: refers to the conditionally independent dimensions of the distribution (the distributions batch shape minus the plates)
-        # k: refers to self.k
-        # k?: refers to an optional plate dimension of this ancestral plate. It either doesn't exist, or is the sample
-        #  dimension. If it exists, this means this sample is conditionally dependent on ancestors.
-        # |D_yv|: refers to the *size* of the domain
-        # amt_samples: refers to the current amount of sampled sequences. amt_samples <= k, but it can be lower if there
-        #  are not enough events to sample from (eg |D_yv| < k)
-        # event_shape: refers to the *shape* of the domain elements
-        #  (can be 0, eg Categorical, or equal to |D_yv| for OneHotCategorical)
-
-        ancestral_distrplate_index = -1
-        is_conditional_sample = False
-        distr_plates = orig_distr_plates
-        for i, plate in enumerate(orig_distr_plates):
-            if plate.name == self.plate_name:
-                ancestral_distrplate_index = i
-                is_conditional_sample = True
-                distr_plates = orig_distr_plates.copy()
-                distr_plates.remove(plate)
-                break
-
-        # TODO: This doesn't properly combine two ancestral plates with the same name but different variable index
-        #  (they should merge).
-        all_plates = distr_plates.copy()
-        prev_plate_shape = ()
-        if isinstance(self.joint_log_probs, storch.Tensor):
-            # Previous variables have been sampled. add the prev_plates to all_plates
-            for plate in self.joint_log_probs.plates:
-                if plate not in distr_plates:
-                    all_plates.append(plate)
-                    prev_plate_shape = prev_plate_shape + (plate.n,)
-
-        amt_plates = len(all_plates)
-        amt_distr_plates = len(distr_plates)
-        amt_orig_distr_plates = len(orig_distr_plates)
-        if not distribution.has_enumerate_support:
-            raise ValueError(
-                "Can only perform stochastic beam search for distributions with enumerable support."
-            )
-
-        # |D_yv| x distr_plate[0] x ... x k? x ... x distr_plate[n-1] x events x event_shape
-        support = distribution.enumerate_support(expand=True)
-
-        if ancestral_distrplate_index != -1:
-            # Reduce ancestral dimension in the support. As the dimension is just an expanded version, this should
-            # not change the underlying data.
-            # |D_yv| x distr_plates x events x event_shape
-            support = support[
-                (..., 0)
-                + (slice(None),) * (len(support.shape) - ancestral_distrplate_index - 2)
-            ]
-
-        # Equal to event_shape
-        element_shape = distribution.event_shape
-        support_permutation = (
-            tuple(range(1, amt_distr_plates + 1))
-            + (0,)
-            + tuple(range(amt_distr_plates + 1, len(support.shape)))
-        )
-        # distr_plates x |D_yv| x events x event_shape
-        support = support.permute(support_permutation)
-
-        if amt_plates != amt_distr_plates:
-            # If previous samples had a plate that are not in the distribution plates, add these to the support.
-            support = support[
-                (slice(None),) * amt_distr_plates
-                + (None,) * (amt_plates - amt_distr_plates)
-            ]
-            # plates x |D_yv| x events x event_shape
-            support = support.expand(
-                (-1,) * amt_distr_plates
-                + prev_plate_shape
-                + (-1,) * (len(support.shape) - amt_distr_plates - 1)
-            )
-        support = storch.Tensor(support, [], all_plates)
-
-        support_k_index = amt_plates
-
-        # Equal to events: Shape for the different conditional independent dimensions
-        events = support.shape[
-            amt_plates + 1 : -len(element_shape) if len(element_shape) > 0 else None
-        ]
-
         ranges = []
-        for size in events:
+        for size in event_shape:
             ranges.append(list(range(size)))
 
-        with storch.ignore_wrapping():
-            # |D_yv| x (|distr_plates| + |k?| + |event_dims|) * (1,) x |D_yv|
-            support_non_expanded: torch.Tensor = distribution.enumerate_support(
-                expand=False
-            )
-            # Compute the log-probability of the different events
-            # |D_yv| x distr_plate[0] x ... k? ... x distr_plate[n-1] x events
-            d_log_probs = distribution.log_prob(support_non_expanded)
-
-            # Note: Use amt_orig_distr_plates here because it might include k? dimension. amt_distr_plates filters this one.
-            # distr_plate[0] x ... k? ... x distr_plate[n-1] x |D_yv| x events
-            d_log_probs = storch.Tensor(
-                d_log_probs.permute(
-                    tuple(range(1, amt_orig_distr_plates + 1))
-                    + (0,)
-                    + tuple(
-                        range(
-                            amt_orig_distr_plates + 1,
-                            amt_orig_distr_plates + 1 + len(events),
-                        )
-                    )
-                ),
-                [],
-                orig_distr_plates,
-            )
-        if is_conditional_sample:
-            # Gather the correct log probabilities
-            # distr_plate[0] x ... k ... x distr_plate[n-1] x |D_yv| x events
-            # TODO: Move this down below to the other scary TODO
-            d_log_probs = self.last_plate.on_unwrap_tensor(d_log_probs)
-            # Permute the dimensions of d_log_probs st the k dimension is after the plates.
-            for i, plate in enumerate(d_log_probs.multi_dim_plates()):
-                if plate.name == self.plate_name:
-                    # k is present in the plates
-                    d_log_probs.plates.remove(plate)
-                    # distr_plates x k x |D_yv| x events
-                    d_log_probs._tensor = d_log_probs._tensor.permute(
-                        tuple(range(0, i))
-                        + tuple(range(i + 1, amt_orig_distr_plates))
-                        + (i,)
-                        + tuple(range(amt_orig_distr_plates, len(d_log_probs.shape)))
-                    )
-                    break
-
-        # plates x k x events
-        sampled_support_indices = support.new_zeros(
-            size=support.shape[:support_k_index]  # distr_plates
-            + (self.k,)
-            + support.shape[
-                support_k_index + 1 : -len(element_shape)
-                if len(element_shape) > 0
-                else None
-            ],  # events
-            dtype=torch.long,
-        )
-
         amt_samples = 0
-        self.parent_indexing = None
-        if self.joint_log_probs is not None:
+        parent_indexing = None
+        if joint_log_probs is not None:
             # Initialize a tensor (self.parent_indexing) that keeps track of what samples link to previous choices of samples
-            # Note that self.joint_log_probs.shape[-1] is amt_samples, not k. It's possible that amt_samples < k!
-            amt_samples = self.joint_log_probs.shape[-1]
+            # Note that joint_log_probs.shape[-1] is amt_samples, not k. It's possible that amt_samples < k!
+            amt_samples = joint_log_probs.shape[-1]
             # plates x k
-            self.parent_indexing = support.new_zeros(
+            parent_indexing = support.new_zeros(
                 size=support.shape[:amt_plates] + (self.k,), dtype=torch.long
             )
 
             # probably can go wrong if plates are missing.
-            self.parent_indexing[..., :amt_samples] = left_expand_as(
-                torch.arange(amt_samples), self.parent_indexing
+            parent_indexing[..., :amt_samples] = left_expand_as(
+                torch.arange(amt_samples), parent_indexing
             )
-
+        # plates x k x events
+        sampled_support_indices = support.new_zeros(
+            size=support.shape[:amt_plates]  # plates
+            + (self.k,)
+            + support.shape[
+                amt_plates + 1 : -len(element_shape) if len(element_shape) > 0 else None
+            ],  # events
+            dtype=torch.long,
+        )
         # Sample independent tensors in sequence
         # Iterate over the different (conditionally) independent samples being taken (the events)
         for indices in itertools.product(*ranges):
@@ -319,7 +87,7 @@ class SampleWithoutReplacement(SamplingMethod):
             # distr_plates x k? x |D_yv|
             yv_log_probs = d_log_probs[(...,) + indices]
             first_sample = False
-            if self.joint_log_probs is None:
+            if joint_log_probs is None:
                 # We also know that k? is not present, so distr_plates x |D_yv|
                 all_joint_log_probs = yv_log_probs
                 # First condition on max being 0:
@@ -332,17 +100,17 @@ class SampleWithoutReplacement(SamplingMethod):
                     dim=-2,
                     index=right_expand_as(
                         # Use the parent_indexing to select the correct plate samples. Make sure to limit to amt_samples!
-                        self.parent_indexing[..., :amt_samples],
+                        parent_indexing[..., :amt_samples],
                         yv_log_probs,
                     ),
                 )
                 # self.joint_log_probs: prev_plates x amt_samples
                 # plates x amt_samples x |D_yv|
-                all_joint_log_probs = self.joint_log_probs.unsqueeze(-1) + yv_log_probs
+                all_joint_log_probs = joint_log_probs.unsqueeze(-1) + yv_log_probs
             else:
                 # self.joint_log_probs: plates x amt_samples
                 # plates x amt_samples x |D_yv|
-                all_joint_log_probs = self.joint_log_probs.unsqueeze(
+                all_joint_log_probs = joint_log_probs.unsqueeze(
                     -1
                 ) + yv_log_probs.unsqueeze(-2)
 
@@ -360,7 +128,7 @@ class SampleWithoutReplacement(SamplingMethod):
                     cond_G_yv, amt_samples, dim=-1
                 )
                 # plates x amt_samples
-                self.joint_log_probs = all_joint_log_probs.gather(dim=-1, index=arg_top)
+                joint_log_probs = all_joint_log_probs.gather(dim=-1, index=arg_top)
                 # Index for the selected samples. Uses slice(amt_samples) for the first index in case k > |D_yv|
                 # (:) * amt_plates + (indices for events) + amt_samples
                 indexing = (
@@ -379,9 +147,9 @@ class SampleWithoutReplacement(SamplingMethod):
                     cond_G_yv, amt_samples, dim=-1
                 )
                 # Gather corresponding joint log probabilities. First reshape like previous to plates x (k * |D_yv|).
-                self.joint_log_probs = all_joint_log_probs.reshape(
-                    cond_G_yv.shape
-                ).gather(dim=-1, index=arg_top)
+                joint_log_probs = all_joint_log_probs.reshape(cond_G_yv.shape).gather(
+                    dim=-1, index=arg_top
+                )
 
                 # |D_yv|
                 size_domain = yv_log_probs.shape[-1]
@@ -390,11 +158,11 @@ class SampleWithoutReplacement(SamplingMethod):
                 # plates x amt_samples
                 chosen_parents = arg_top // size_domain
                 sampled_support_indices = sampled_support_indices.gather(
-                    dim=support_k_index,
+                    dim=amt_plates,
                     index=right_expand_as(chosen_parents, sampled_support_indices),
                 )
-                if self.parent_indexing is not None:
-                    self.parent_indexing = self.parent_indexing.gather(
+                if parent_indexing is not None:
+                    parent_indexing = parent_indexing.gather(
                         dim=-1, index=chosen_parents
                     )
                 # Index for the selected samples. Uses slice(amt_samples) for the first index in case k > |D_yv|
@@ -409,10 +177,20 @@ class SampleWithoutReplacement(SamplingMethod):
         if amt_samples < self.k:
             # plates x amt_samples x events
             sampled_support_indices = sampled_support_indices[
-                (...,) + (slice(amt_samples),) + (slice(None),) * len(events)
+                (...,) + (slice(amt_samples),) + (slice(None),) * len(ranges)
             ]
         expanded_indices = right_expand_as(sampled_support_indices, support)
-        return support.gather(dim=support_k_index, index=expanded_indices)
+        sample = support.gather(dim=amt_plates, index=expanded_indices)
+        return sample, joint_log_probs, parent_indexing
+
+    def create_plate(self, plate_size: int, plates: [storch.Plate]) -> AncestralPlate:
+        plate = super().create_plate(plate_size, plates)
+        plate.perturb_log_probs = storch.Tensor(
+            self.perturb_log_probs._tensor,
+            [self.perturb_log_probs],
+            self.perturb_log_probs.plates + [plate],
+        )
+        return plate
 
     def plate_weighting(
         self, tensor: storch.StochasticTensor, plate: storch.Plate
@@ -457,117 +235,6 @@ class SampleWithoutReplacement(SamplingMethod):
         )
 
 
-class AncestralPlate(storch.Plate):
-    def __init__(
-        self,
-        name: str,
-        n: int,
-        parents: List[storch.Plate],
-        variable_index: int,
-        parent_plate: AncestralPlate,
-        selected_samples: storch.Tensor,
-        log_probs: storch.Tensor,
-        perturb_log_probs: storch.Tensor,
-        weight: Optional[storch.Tensor] = None,
-    ):
-        super().__init__(name, n, parents, weight)
-        assert (not parent_plate and variable_index == 0) or (
-            parent_plate.n <= self.n and parent_plate.variable_index < variable_index
-        )
-        self.parent_plate = parent_plate
-        self.selected_samples = selected_samples
-        self.log_probs = storch.Tensor(
-            log_probs._tensor, [log_probs], log_probs.plates + [self]
-        )
-        self.perturb_log_probs = storch.Tensor(
-            perturb_log_probs._tensor,
-            [perturb_log_probs],
-            perturb_log_probs.plates + [self],
-        )
-        self.variable_index = variable_index
-        self._in_recursion = False
-        self._override_equality = False
-
-    def __eq__(self, other):
-        if self._override_equality:
-            return other.name == self.name
-        return (
-            super().__eq__(other)
-            and isinstance(other, AncestralPlate)
-            and self.variable_index == other.variable_index
-        )
-
-    def __repr__(self):
-        return (
-            "(Ancestral, " + self.variable_index.__repr__() + super().__repr__() + ")"
-        )
-
-    def on_collecting_args(self, plates: [storch.Plate]) -> bool:
-        """
-        Filter the collected plates to only keep the AncestralPlates (with the same name) that has the highest variable index.
-        :param plates:
-        :return:
-        """
-        if self._in_recursion:
-            self._override_equality = True
-        for plate in plates:
-            if plate.name == self.name:
-                if not isinstance(plate, AncestralPlate):
-                    raise ValueError(
-                        "Received a plate with name "
-                        + plate.name
-                        + " that is not also an AncestralPlate."
-                    )
-                if plate.variable_index > self.variable_index:
-                    # Only keep ancestral plates with the highest variable index
-                    return False
-        return True
-
-    def on_unwrap_tensor(self, tensor: storch.Tensor) -> storch.Tensor:
-        """
-        Gets called whenever the given tensor is being unwrapped and unsqueezed for batch use.
-        This method should not be called on tensors whose variable index is higher than this plates.
-        :param tensor: The input tensor that is being unwrapped
-        :return: The tensor that will be unwrapped and unsqueezed in the future. Can be a modification of the input tensor.
-        """
-        if self._in_recursion:
-            # Required when calling storch.gather in this method. It will call on_unwrap_tensor again.
-            return tensor
-        for i, plate in enumerate(tensor.multi_dim_plates()):
-            if plate.name != self.name:
-                continue
-            assert isinstance(plate, AncestralPlate)
-            if plate.variable_index == self.variable_index:
-                return tensor
-            # This is true by the filtering at on_collecting_args
-            assert plate.variable_index < self.variable_index
-
-            parent_plates = []
-            current_plate = self
-
-            # Collect the list of plates from the tensors variable index to this plates variable index
-            while current_plate.variable_index != plate.variable_index:
-                parent_plates.append(current_plate)
-                current_plate = current_plate.parent_plate
-            assert current_plate == plate
-
-            # Go over all parent plates and gather their respective choices.
-            for parent_plate in reversed(parent_plates):
-                self._in_recursion = True
-                expanded_selected_samples = expand_with_ignore_as(
-                    parent_plate.selected_samples, tensor, self.name
-                )
-                self._override_equality = False
-                # Gather what samples of the tensor are chosen by this plate (parent_plate)
-                tensor = storch.gather(
-                    tensor, parent_plate.name, expanded_selected_samples
-                )
-                self._in_recursion = False
-                self._override_equality = False
-            break
-        return tensor
-
-
 def log1mexp(a: torch.Tensor) -> torch.Tensor:
     """See appendix A of http://jmlr.org/papers/v21/19-985.html.
     Numerically stable implementation of log(1-exp(a))"""
@@ -602,31 +269,3 @@ def right_expand_as(tensor, expand_as):
 def left_expand_as(tensor, expand_as):
     diff = expand_as.ndim - tensor.ndim
     return tensor[(None,) * diff].expand(expand_as.shape[:diff] + (-1,) * tensor.ndim)
-
-
-def expand_with_ignore_as(
-    tensor, expand_as, ignore_dim: Union[str, int]
-) -> torch.Tensor:
-    """
-    Expands the tensor like expand_as, but ignores a single dimension.
-    Ie, if tensor is of size a x b,  expand_as of size d x a x c and dim=-1, then the return will be of size d x a x b.
-    It also automatically expands all plate dimensions correctly.
-    :param ignore_dim: Can be a string referring to the plate dimension
-    """
-    # diff = expand_as.ndim - tensor.ndim
-    def _expand_with_ignore(tensor, expand_as, dim: int):
-        new_dims = expand_as.ndim - tensor.ndim
-        # after_dims = tensor.ndim - dim
-        return tensor[(...,) + (None,) * new_dims].expand(
-            expand_as.shape[:dim]
-            + (-1,)
-            + (expand_as.shape[dim + 1 :] if dim != -1 else ())
-        )
-
-    if isinstance(ignore_dim, str):
-        return storch.deterministic(
-            _expand_with_ignore, expand_plates=True, dim=ignore_dim
-        )(tensor, expand_as)
-    return storch.deterministic(_expand_with_ignore, expand_plates=True)(
-        tensor, expand_as, ignore_dim
-    )

--- a/storch/sampling/swor.py
+++ b/storch/sampling/swor.py
@@ -14,6 +14,8 @@ class SampleWithoutReplacement(SamplingMethod):
     REINFORCE without replacement https://openreview.net/forum?id=r1lgTGL5DE
     """
 
+    EPS = 1e-8
+
     def __init__(self, plate_name: str, k: int, biased_iw: bool = False):
         super().__init__(plate_name)
         if k < 2:
@@ -406,7 +408,7 @@ class SampleWithoutReplacement(SamplingMethod):
     def plate_weighting(
         self, tensor: storch.StochasticTensor, plate: storch.Plate
     ) -> Optional[storch.Tensor]:
-        return self.compute_iw(plate, self.biased).detach()
+        return self.compute_iw(plate, self.biased_iw).detach()
 
     def compute_iw(self, plate: AncestralPlate, biased: bool):
         # Compute importance weights. The kth sample has 0 weight, and is only used to compute the importance weights

--- a/storch/sampling/unordered_set.py
+++ b/storch/sampling/unordered_set.py
@@ -1,0 +1,106 @@
+from typing import Optional
+
+from storch.sampling.swor import log1mexp, SampleWithoutReplacement
+import storch
+import torch
+
+
+class UnorderedSet(SampleWithoutReplacement):
+    def __init__(
+        self,
+        plate_name: str,
+        k: int,
+        comp_leave_two_out: bool = False,
+        exact_integration: bool = False,
+        num_int_points: int = 1000,
+        a: float = 5.0,
+    ):
+        super().__init__(plate_name, k)
+        self.comp_leave_two_out = comp_leave_two_out
+        self.exact_integration = exact_integration
+        self.num_int_points = num_int_points
+        self.a = a
+
+    def plate_weighting(
+        self, tensor: storch.StochasticTensor, plate: storch.Plate
+    ) -> Optional[storch.Tensor]:
+        # plates_w_k is a sequence of plates of which one is the input ancestral plate
+
+        # Computes p(s) * R(S^k, s), or the probability of the sample times the leave-one-out ratio.
+        # For details, see https://openreview.net/pdf?id=rklEj2EFvB
+        # Code based on https://github.com/wouterkool/estimating-gradients-without-replacement/blob/master/bernoulli/gumbel.py
+        log_probs = plate.log_probs.detach()
+
+        # Compute integration points for the trapezoid rule: v should range from 0 to 1, where both v=0 and v=1 give a value of 0.
+        # As the computation happens in log-space, take the logarithm of the result.
+        # N
+        v = (
+            torch.arange(1, self.num_int_points, out=log_probs._tensor.new())
+            / self.num_int_points
+        )
+        log_v = v.log()
+
+        # Compute log(1-v^{exp(log_probs+a)}) in a numerically stable way in log-space
+        # Uses the gumbel_log_survival function from
+        # https://github.com/wouterkool/estimating-gradients-without-replacement/blob/master/bernoulli/gumbel.py
+        # plates_w_k x N
+        g_bound = (
+            log_probs[..., None]
+            + self.a
+            + torch.log(-log_v)[log_probs.plate_dims * (None,) + (slice(None),)]
+        )
+
+        # Gumbel log survival: log P(g > g_bound) = log(1 - exp(-exp(-g_bound))) for standard gumbel g
+        # If g_bound >= 10, use the series expansion for stability with error O((e^-10)^6) (=8.7E-27)
+        # See https://www.wolframalpha.com/input/?i=log%281+-+exp%28-y%29%29
+        y = torch.exp(g_bound)
+        # plates_w_k x N
+        terms = torch.where(
+            g_bound >= 10, -g_bound - y / 2 + y ** 2 / 24 - y ** 4 / 2880, log1mexp(y)
+        )
+
+        # Compute integrands (without subtracting the special value s)
+        # plates x N
+        sum_of_terms = storch.sum(terms, plate)
+        phi_S = storch.logsumexp(log_probs, plate)
+        phi_D_min_S = log1mexp(phi_S)
+
+        # plates x N
+        integrand = (
+            sum_of_terms
+            + torch.expm1(self.a + phi_D_min_S)[..., None]
+            * log_v[phi_D_min_S.plate_dims * (None,) + (slice(None),)]
+        )
+
+        # Subtract one term the for element that is left out in R
+        # Automatically unsqueezes correctly using plate dimensions
+        # plates_w_k x N
+        integrand_without_s = integrand - terms
+
+        # plates
+        log_p_S = integrand.logsumexp(dim=-1)
+        # plates_w_k
+        log_p_S_without_s = integrand_without_s.logsumexp(dim=-1)
+
+        # plates_w_k
+        log_leave_one_out = log_p_S_without_s - log_p_S
+
+        if self.comp_leave_two_out:
+            # Compute the integrands for the 2nd order leave one out ratio.
+            # Make sure to properly choose the indices: We shouldn't subtract the same term twice on the diagonals.
+            # k x k
+            skip_diag = storch.Tensor(
+                1 - torch.eye(plate.n, out=log_probs._tensor.new()), [], [plate]
+            )
+            # plates_w_k x k x N
+            integrand_without_ss = (
+                integrand_without_s[..., None, :]
+                - terms[..., None, :] * skip_diag[..., None]
+            )
+            # plates_w_k x k
+            log_p_S_without_ss = integrand_without_ss.logsumexp(dim=-1)
+
+            plate.log_snd_leave_one_out = log_p_S_without_ss - log_p_S_without_s
+
+        # Return the unordered set estimator weighting
+        return (log_leave_one_out + log_probs).exp().detach()

--- a/storch/storch.py
+++ b/storch/storch.py
@@ -3,6 +3,7 @@ from typing import List, Union, Optional, Tuple
 import storch
 import torch
 
+from storch.typing import AnyTensor
 
 _index = Union[str, int, storch.Plate]
 _indices = Union[List[_index], _index]
@@ -54,7 +55,7 @@ def expand_as(tensor: _tensor, expand_as: _tensor) -> torch.Tensor:
 
 
 def _handle_inputs(
-    tensor: torch.Tensor,
+    tensor: AnyTensor,
     plates: Optional[List[storch.Plate]],
     plate_names: Optional[List[str]],
 ) -> (storch.Tensor, List[storch.Plate]):
@@ -91,7 +92,7 @@ def gather(input: storch.Tensor, dim: str, index: storch.Tensor):
 
 
 def reduce_plates(
-    tensor: torch.Tensor,
+    tensor: AnyTensor,
     *,
     plates: Optional[List[storch.Plate]] = None,
     plate_names: Optional[List[str]] = None,

--- a/storch/storch.py
+++ b/storch/storch.py
@@ -113,6 +113,18 @@ def reduce_plates(
     return tensor
 
 
+def _isroot(plate: storch.Plate, plates: [storch.Plate]):
+    """
+    Returns true if the plate is a root of the list of plates.
+    """
+    for parent in plate.parents:
+        if parent in plates:
+            return False
+        if not _isroot(parent, plates):
+            return False
+    return True
+
+
 def order_plates(plates: [storch.Plate], reverse=False):
     """
     Topologically order the given plates.
@@ -124,7 +136,7 @@ def order_plates(plates: [storch.Plate], reverse=False):
     in_edges = {}
     out_edges = {p.name: [] for p in plates}
     for p in plates:
-        if not p.parents:
+        if _isroot(p, plates):
             roots.append(p)
         in_edges[p.name] = p.parents.copy()
         for _p in p.parents:

--- a/storch/tensor.py
+++ b/storch/tensor.py
@@ -658,15 +658,15 @@ class StochasticTensor(Tensor):
         plates: [Plate],
         name: str,
         n: int,
-        sampling_method: Optional[storch.Method],
         distribution: Distribution,
         requires_grad: bool,
+        method: Optional[storch.Method] = None,
     ):
         self.distribution = distribution
         super().__init__(tensor, parents, plates, name)
         self._requires_grad = requires_grad
         self.n = n
-        self.sampling_method = sampling_method
+        self.method = method
         self.param_grads = {}
         self._grad = None
 
@@ -683,6 +683,9 @@ class StochasticTensor(Tensor):
     @property
     def grad(self):
         return self.param_grads
+
+    def _set_method(self, method: storch.Method):
+        self.method = method
 
 
 is_tensor = lambda a: isinstance(a, torch.Tensor) or isinstance(a, Tensor)

--- a/storch/typing.py
+++ b/storch/typing.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 import torch
-from storch.tensor import Tensor, StochasticTensor, CostTensor
+import storch
 from storch.method.baseline import Baseline
 from typing import Union, List, Tuple, Callable
 from torch import Size
 from torch.distributions import Bernoulli, Categorical, OneHotCategorical
 
 # from storch.seq import BlackboxTensor
+
+AnyTensor = Union[storch.Tensor, torch.Tensor]
 
 _size = Union[Size, List[int], Tuple[int, ...]]
 
@@ -16,4 +18,4 @@ Dims = Union[int, _size]
 
 DiscreteDistribution = Union[Bernoulli, Categorical, OneHotCategorical]
 
-BaselineFactory = Callable[[StochasticTensor, CostTensor], Baseline]
+BaselineFactory = Callable[[storch.StochasticTensor, storch.CostTensor], Baseline]

--- a/test/test.py
+++ b/test/test.py
@@ -10,10 +10,10 @@ torch.manual_seed(0)
 mu_prior = torch.tensor([2.0, -3.0], requires_grad=True)
 theta = torch.tensor([4.0, 5])
 
-lax_method = storch.LAX("mu", in_dim=2)
-expect = storch.Expect("k")
-score_method = storch.ScoreFunction("white_noise_1", n_samples=2)
-infer_method = storch.Infer("white_noise_2", Normal)
+lax_method = storch.method.LAX("mu", in_dim=2)
+expect = storch.method.Expect("k")
+score_method = storch.method.ScoreFunction("white_noise_1", n_samples=2)
+infer_method = storch.method.Infer("white_noise_2", Normal)
 
 
 def loss(v):

--- a/test/test_expect.py
+++ b/test/test_expect.py
@@ -2,7 +2,7 @@ import storch
 import torch
 from torch.distributions import Bernoulli, OneHotCategorical
 
-expect = storch.Expect("x")
+expect = storch.method.Expect("x")
 probs = torch.tensor([0.01, 0.01, 0.01, 0.01, 0.01, 0.95], requires_grad=True)
 indices = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
 b = OneHotCategorical(probs=probs)
@@ -14,7 +14,7 @@ storch.backward()
 
 expect_grad = z.grad["probs"].clone()
 
-method = storch.ScoreFunction("x", 1, baseline_factory="none")
+method = storch.method.UnorderedSetEstimator("x", k=6)
 # method = storch.REBAR()
 grads = []
 for i in range(100):

--- a/test/test_swor.py
+++ b/test/test_swor.py
@@ -21,8 +21,8 @@ plt_n1 = 3
 plt_n2 = 2
 
 # Define swr method
-swr_method = storch.ScoreFunctionWOR("z", k, biased=True, use_baseline=False)
-normal_method1 = storch.ScoreFunction("n1", n_samples=plt_n1)
+swr_method = storch.method.ScoreFunctionWOR("z", k, biased=True, use_baseline=False)
+normal_method1 = storch.method.ScoreFunction("n1", n_samples=plt_n1)
 
 
 l_entropy = torch.tensor([-3.0, -3.0, 2, -2.0], requires_grad=True)
@@ -69,7 +69,7 @@ print("z4", z_4)
 assert z_3.shape == (plt_n1, k, event, d_yv) or z_3.shape == (k, plt_n1, event, d_yv)
 assert z_4.shape == (plt_n1, k, d_yv) or z_4.shape == (k, plt_n1, d_yv)
 
-normal_method2 = storch.ScoreFunction("n2", n_samples=plt_n2)
+normal_method2 = storch.method.ScoreFunction("n2", n_samples=plt_n2)
 # n2
 n2 = normal_method2.sample(dn1)
 # n2 x |D_yv|
@@ -82,7 +82,7 @@ d5 = OneHotCategorical(logits=n_l_entropy)
 z_5 = swr_method.sample(d5)
 
 print("z5", z_5)
-if isinstance(swr_method, storch.SampleWithoutReplacementMethod):
+if isinstance(swr_method.sampling_method, storch.sampling.SampleWithoutReplacement):
     assert z_5.shape == (plt_n1, plt_n2, k, d_yv) or z_5.shape == (
         plt_n2,
         plt_n1,

--- a/test/test_swr.py
+++ b/test/test_swr.py
@@ -21,8 +21,8 @@ plt_n1 = 3
 plt_n2 = 2
 
 # Define swr method
-swr_method = storch.ScoreFunctionWOR("z", k - 1, biased=True, use_baseline=False)
-normal_method1 = storch.ScoreFunction("n1", plt_n1)
+swr_method = storch.ScoreFunctionWOR("z", k, biased=True, use_baseline=False)
+normal_method1 = storch.ScoreFunction("n1", n_samples=plt_n1)
 
 l_entropy = torch.tensor([-3.0, -3.0, 2, -2.0], requires_grad=True)
 h_entropy = torch.tensor([-0.1, 0.1, 0.05, -0.05], requires_grad=True)
@@ -68,7 +68,7 @@ print("z4", z_4)
 assert z_3.shape == (plt_n1, k, event, d_yv)
 assert z_4.shape == (plt_n1, k, d_yv)
 
-normal_method2 = storch.ScoreFunction("n2", plt_n2)
+normal_method2 = storch.ScoreFunction("n2", n_samples=plt_n2)
 # n2
 n2 = normal_method2.sample(dn1)
 # n2 x |D_yv|


### PR DESCRIPTION
Now, `storch.sampling.SamplingMethod` contains the behaviour for sampling from a distribution, while `storch.method.Method` handles the estimator to use (REINFORCE, Reparameterization, RELAX, baselines, etc.). This is done to allow reuse of sampling methods across different gradient estimation methods. 

Furthermore, abstract classes for sampling for sequences are added to allow reuse of sequence-specific sampling methods and techniques. 